### PR TITLE
Fix broken idempotence.

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,7 +6,6 @@
   with_items:
     - docker
     - docker-common
-    - container-selinux
     - docker-selinux
     - docker-engine
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,7 +6,6 @@
   with_items:
     - docker
     - docker-common
-    - docker-selinux
     - docker-engine
 
 - name: Add Docker GPG key.


### PR DESCRIPTION
Cron builds seem to start failing as of this morning, possibly due to the `container-selinux` removal on CentOS 7.