### PR TITLE
Add var to customize docker pkg state

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
 docker_edition: 'ce'
 docker_package: "docker-{{ docker_edition }}"
+docker_package_state: present
 
 # Docker Compose options.
 docker_install_compose: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install Docker.
-  package: name={{ docker_package }} state=present
+  package: name={{ docker_package }} state={{ docker_package_state }}
 
 - name: Ensure Docker is started and enabled at boot.
   service:


### PR DESCRIPTION
By default var will be `present` to do not break legacy.

Fixes #14