### PR TITLE
Open up support for armhf architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterpri
 Docker Compose installation options.
 
     docker_apt_release_channel: stable
-    docker_apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+    docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 (Used only for Debian/Ubuntu.) You can switch the channel to `edge` if you want to use the Edge release.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
-docker_apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 # Used only for RedHat/CentOS.
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo


### PR DESCRIPTION
Nice module and thanks for making it available!

Could you please consider this PR to add armhf package support to the default configuration? I know I can override the repository URL in my playbook, but it would be nice for it to "just work" for both amd64 and armhf architectures. By removing this bit apt should fall back on the value in the apt configuration.

There are also s390x packages for Xenial:
https://download.docker.com/linux/ubuntu/dists/xenial/stable/
I presume this would add support for that architecture too, though do not have access to such a system to test.