### PR TITLE
Eliminated the need for two OS specific tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
+docker_install: true
 docker_edition: 'ce'
 docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-- include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+- name: OS specific setup
+  include: include: "setup-{{ ansible_os_family }}.yml"
 
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: OS specific setup
-  include: include: "setup-{{ ansible_os_family }}.yml"
+  include: "setup-{{ ansible_os_family }}.yml"
   when: docker_install
 
 - name: Install Docker.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,18 @@
 ---
 - name: OS specific setup
   include: include: "setup-{{ ansible_os_family }}.yml"
+  when: docker_install
 
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
+  when: docker_install
 
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker
     state: started
     enabled: yes
+  when: docker_install
 
 - include: docker-compose.yml
   when: docker_install_compose


### PR DESCRIPTION
First of all, great role! This role will help a great deal and this is the first of several pull requests where we have changed this to suit our needs and think others would benefit as well.

There are two changes that have been made:

### 1. Eliminated the need for two OS specific tasks
I like to keep all of our plays built with the "K.I.S.S" method. "Keeping it sweet and simple." That means I prefer to have as few "skipped" tasks as I possibly can in a play. Including OS specific tasks can be done with a single task this eliminates at least one task from your plan and giving an overall cleaner output. Very minor I know.

### 2. Added ability to completely skip the role.
There may be times where a single host in a group shouldn't have docker installed and you want to ensure that it is never mistakenly installed. Simply adding `docker_install: false` and `docker_install_compose: false` to the host_vars for the remote. This will ensure that anytime the role is ran against the hosts group it will simply skip the installation of the tasks.
