### PR TITLE
Adds an initial Docker daemon configuration for DNS resolvers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,11 @@ docker_install_compose: true
 docker_compose_version: "1.13.0"
 docker_compose_path: /usr/local/bin/docker-compose
 
+# Docker Daemon Configuration Options.
+docker_daemon_dns_resolvers:
+  - "8.8.8.8"
+  - "8.8.4.4"
+
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
 docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,15 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Ensure Docker configuration is present.
+  template:
+    src: etc/docker/daemon.json.j2
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: docker
+    mode: 0640
+  notify: restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Ensure Docker directory exists.
+  file:
+    path: /etc/docker
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
 - name: Ensure Docker configuration is present.
   template:
     src: etc/docker/daemon.json.j2

--- a/templates/etc/docker/daemon.json.j2
+++ b/templates/etc/docker/daemon.json.j2
@@ -1,0 +1,3 @@
+{
+    "dns": ["{{ '", "'.join(docker_daemon_dns_resolvers) }}"]
+}


### PR DESCRIPTION
Simple PR to add a basic Docker daemon configuration, which only adds DNS resolvers at this point.