### PR TITLE
Ubuntu 1604 dmsetup

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,6 +16,18 @@
     - apt-transport-https
     - ca-certificates
 
+# Fix for https://github.com/docker/docker/issues/23347
+- name: Install dmsetup for Ubuntu 16.04
+  apt:
+    pkg: dmsetup
+    state: present
+  register: dmsetup_result
+  when: ansible_distribution_version|version_compare('16.04', '=')
+
+- name: Run dmsetup for Ubuntu 16.04
+  command: dmsetup mknodes
+  when: dmsetup_result.changed
+
 - name: Add Docker apt key.
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,6 +6,7 @@
   with_items:
     - docker
     - docker-engine
+    - docker.io
 
 - name: Ensure depdencies are installed.
   apt:


### PR DESCRIPTION
This patch adds a required package on Ubuntu 16.04, which is required to work-around an upstream bug docker/docker#23347