### PR TITLE
Added packages for Ubuntu Trusty

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
+docker_install: true
 docker_edition: 'ce'
 docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-- include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+- name: OS specific setup
+  include: include: "setup-{{ ansible_os_family }}.yml"
 
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: OS specific setup
-  include: include: "setup-{{ ansible_os_family }}.yml"
+  include: "setup-{{ ansible_os_family }}.yml"
   when: docker_install
 
 - name: Install Docker.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,18 @@
 ---
 - name: OS specific setup
   include: include: "setup-{{ ansible_os_family }}.yml"
+  when: docker_install
 
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
+  when: docker_install
 
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker
     state: started
     enabled: yes
+  when: docker_install
 
 - include: docker-compose.yml
   when: docker_install_compose

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,6 +15,20 @@
     - apt-transport-https
     - ca-certificates
 
+- name: Get Kernel release
+  command: uname -r
+  register: docker_kernel_release
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"
+  
+- name: Ensure Trusty packages are installed
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "linux-image-extra-{{ docker_kernel_release }}"
+    - linux-image-extra-virtual
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"
+
 - name: Add Docker apt key.
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
As mentioned in #22 the packages for docker in Trusty 14.04 are missing from the role. This pull should resolve that issue. 