### PR TITLE
added required packages installation as without those was not able to…

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -38,3 +38,16 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: yes
+
+- name: Install packages required for docker_container see https://docs.ansible.com/ansible/docker_container_module.html#requirements-on-host-that-executes-module
+  apt: name={{item}} state=installed
+  become: yes
+  with_items:
+       - python-dev
+       - python-pip
+
+
+- name: pip install docker-py via pip module
+  pip: 
+    name: docker-py
+    version: 1.10.6


### PR DESCRIPTION
Added some packages for Debian which are required to create a container. Below is the playbook example which failed without those commands.

---

- hosts: all
  roles:
    - geerlingguy.docker
  tasks:
    - name: create gitolite--docker container
      docker_container: 
        name: mongodbdocker
        image: mongo:3.2
        state: started
        ports:
          - "8082:27017"
        volumes:
          - "/docker/volumes/catalogermongodbdatadir:/data/db"
      become: yes   