### PR TITLE
Comply with Ansible 2.4 new `include` method

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- import_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- import_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Docker.
@@ -14,5 +14,5 @@
     state: started
     enabled: yes
 
-- include: docker-compose.yml
+- import_tasks: docker-compose.yml
   when: docker_install_compose


### PR DESCRIPTION
Since the variables are computed in parent playbook, I reckon using `import_tasks` (static) is more appropriate than `include_tasks` (dynamic). The ansible docs are very unclear on it:
http://docs.ansible.com/ansible/latest/playbooks_reuse.html#differences-between-static-and-dynamic