### PR TITLE
Adding devicemapper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ Docker Compose installation options.
 
 (Used only for RedHat/CentOS.) You can enable the Edge or Test repo by setting the respective vars to `1`.
 
+### devicemapper
+
+Out of the box this role deploys docker with the overlay driver, but the only
+officially supported configuration of Docker on RedHat/CentOS is to use device
+mapper as the storage driver (Not to be confused with `docker volume`). Docker
+can configure the lvm thin provisioning when provided a raw block device (such
+as a second disk). To deploy this configuration, set the following variables in
+your deploy:
+
+    docker_devicemapper_raw_device: /dev/sdb # Or /dev/vdb or ...
+    docker_configure_daemon: true
+
+For more information, see the [device mapper driver][devicemapper] documentation.
+
+### Docker daemon configuration
+
+To configure devicemapper as the storage driver, this role has to configure the
+docker daemon via `daemon.json`, but you can also use this to configure the
+daemon as you wish by overriding `docker_daemon_config`. This yaml hash is then
+converted to json. Making changes to `daemon.json` then require a restart of the
+service, but this role does not default to restarting the service. To trigger a
+restart when reconfiguring the daemon, set `docker_restart` to `true`.
+
 ## Use with Ansible (and `docker` Python library)
 
 Many users of this role wish to also use Ansible to then _build_ Docker images and manage Docker containers on the server where Docker is installed. In this case, you can easily add in the `docker` Python library using the `geerlingguy.pip` role:
@@ -71,3 +94,5 @@ MIT / BSD
 ## Author Information
 
 This role was created in 2017 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).
+
+[devicemapper]: https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ docker_configure_daemon: false
 docker_daemon_config:
   storage-driver: "devicemapper"
   storage-opts:
-    - "dm.directlvm_device={{ docker_devicemapper_raw_device|mandatory }}"
+    - "dm.directlvm_device={{ docker_devicemapper_raw_device|default(omit) }}"
     - "dm.thinp_percent=95"
     - "dm.thinp_metapercent=1"
     - "dm.thinp_autoextend_threshold=80"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,20 @@ docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distrib
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo
 docker_yum_repo_enable_edge: 0
 docker_yum_repo_enable_test: 0
+
+# Conditonally control docker daemon restart
+docker_restart: false
+
+# Used only for devicemapper configuration for RedHat/CentOS
+# docker_devicemapper_raw_device: /dev/sdb
+
+docker_configure_daemon: false
+docker_daemon_config:
+  storage-driver: "devicemapper"
+  storage-opts:
+    - "dm.directlvm_device={{ docker_devicemapper_raw_device|mandatory }}"
+    - "dm.thinp_percent=95"
+    - "dm.thinp_metapercent=1"
+    - "dm.thinp_autoextend_threshold=80"
+    - "dm.thinp_autoextend_percent=20"
+    - "dm.directlvm_device_force=false"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart docker
   service: name=docker state=restarted
+  when: docker_restart

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Configure docker daemon
+  copy:
+    content: "{{ docker_daemon_config|to_nice_json }}"
+    dest: /etc/docker/daemon.json
+    mode: 0600
+  when: docker_configure_daemon
+  notify: restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     group: root
     mode: 0700
   when: docker_daemon_config
-  
+
 - name: Configure docker daemon
   copy:
     content: "{{ docker_daemon_config|to_nice_json }}"
@@ -27,5 +27,5 @@
     state: started
     enabled: yes
 
-- include: docker-compose.yml
+- import_tasks: docker-compose.yml
   when: docker_install_compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,18 @@
 ---
-- include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+- include_tasks: "setup-{{ ansible_os_family }}.yml"
 
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Create /etc/docker
+  file:
+    path: /etc/docker
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  when: docker_daemon_config
+  
 - name: Configure docker daemon
   copy:
     content: "{{ docker_daemon_config|to_nice_json }}"


### PR DESCRIPTION
On RedHat/CentOS, using devicemapper as the storage driver is the preferred production configuration.