### PR TITLE
'include' for tasks has been deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Docker.
@@ -14,5 +14,5 @@
     state: started
     enabled: yes
 
-- include: docker-compose.yml
+- include_tasks: docker-compose.yml
   when: docker_install_compose


### PR DESCRIPTION
The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.