### PR TITLE
Fix apt repo arch issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,8 @@ docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
-docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_deb_arch: "{% if ansible_architecture == 'x86_64' %}amd64{% elif ansible_architecture == 'armv7l' %}armhf{% endif %}"
+docker_apt_repository: "deb [arch={{ docker_deb_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 # Used only for RedHat/CentOS.
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo


### PR DESCRIPTION
There is an issue (at least on ubuntu 14.04) where if you do not specify the arch (e.g. [arch=amd64]) then it will default to i386.  This obviously fails on an x86_64 machine.  

The official docker install docs for Debian/Ubuntu specify that this must be part of the apt repo config.  

This patch adds a line both for amd64 and armv7l.  There may be more arm types that conform to armhf that I'm not aware of.

Edit: What's strange about this issue is that the role works fine at first.  It's not until trying to do an apt update later that the problem is noticed.  