### PR TITLE
Update docker compose task to use block statement

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -1,20 +1,23 @@
+# vi: set ft=ansible :
 ---
 - name: Check current docker-compose version.
-  command: docker-compose --version
+  command: "{{ docker_compose_path }} --version"
   register: docker_compose_current_version
-  changed_when: false
   failed_when: false
+  changed_when: false
 
-- name: Delete existing docker-compose version if it's different.
-  file:
-    path: "{{ docker_compose_path }}"
-    state: absent
+- block:
+    - name: Delete existing docker-compose
+      file:
+        path: "{{ docker_compose_path }}"
+        state: absent
+
+    - name: Install Docker Compose (if configured).
+      get_url:
+        url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
+        dest: "{{ docker_compose_path }}"
+        mode: 0755
   when: >
+    docker_compose_current_version.rc > 0 or (
     docker_compose_current_version.stdout is defined
-    and docker_compose_version not in docker_compose_current_version.stdout
-
-- name: Install Docker Compose (if configured).
-  get_url:
-    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
-    dest: "{{ docker_compose_path }}"
-    mode: 0755
+    and docker_compose_version not in docker_compose_current_version.stdout)


### PR DESCRIPTION
I think these 2 tasks should be grouped in a block, we should only install docker-compose when it's not yet installed. 