### PR TITLE
Debian apt amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterpri
 
 Docker Compose installation options.
 
+    docker_apt_arch: amd64
     docker_apt_release_channel: stable
-    docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+    docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 (Used only for Debian/Ubuntu.) You can switch the channel to `edge` if you want to use the Edge release.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,9 @@ docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
-docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+# Architecture must be specified in order for updates to work. Choose between 'amd64' & 'i386'.
+docker_apt_arch: amd64 
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 # Used only for RedHat/CentOS.
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Docker.
@@ -14,5 +14,5 @@
     state: started
     enabled: yes
 
-- include: docker-compose.yml
+- include_tasks: docker-compose.yml
   when: docker_install_compose


### PR DESCRIPTION
According to the docs (https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-using-the-repository#set-up-the-repository), Docker needs the CPU architecture to be specified in the apt source definition under Debian/Ubuntu.

Otherwise updating the sources fails with „N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'https://download.docker.com/linux/ubuntu xenial InRelease' doesn't support architecture 'i386‘“

Although the correct package has been installed!

This PR introduces an additional config param for Debian/Ubuntu to setting the CPU architecture to either amd64 or i386.