### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Docker Compose installation options.
     docker_yum_repo_enable_edge: 0
     docker_yum_repo_enable_test: 0
 
+(Tested only on Ubuntu >16.04) Configure docker beyond proxy
+
+    docker_http_proxy: http://proxy.example.com:8080/ #the trailing slash is very important
+    docker_no_proxy: localhost
+
+Login into docker hub
+
+    docker_hub_username: mine
+    docker_hub_password: ciao
+    docker_hub_email: nobody@example.com
+
 (Used only for RedHat/CentOS.) You can enable the Edge or Test repo by setting the respective vars to `1`.
 
 ## Use with Ansible (and `docker` Python library)

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ Docker Compose installation options.
     docker_http_proxy: http://proxy.example.com:8080/ #the trailing slash is very important
     docker_no_proxy: localhost
 
-Login into docker hub
-
-    docker_hub_username: mine
-    docker_hub_password: ciao
-    docker_hub_email: nobody@example.com
-
 (Used only for RedHat/CentOS.) You can enable the Edge or Test repo by setting the respective vars to `1`.
 
 ## Use with Ansible (and `docker` Python library)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,3 @@ docker_yum_repo_enable_test: 0
 # configure corporate proxy
 docker_http_proxy: ""
 docker_no_proxy: "localhost,127.0.0.1,localaddress,.localdomain.com"
-
-#login into docker hub
-docker_hub_username: ""
-docker_hub_password: ""
-docker_hub_email: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,12 @@ docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distrib
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo
 docker_yum_repo_enable_edge: 0
 docker_yum_repo_enable_test: 0
+
+# configure corporate proxy
+docker_http_proxy: ""
+docker_no_proxy: "localhost,127.0.0.1,localaddress,.localdomain.com"
+
+#login into docker hub
+docker_hub_username: ""
+docker_hub_password: ""
+docker_hub_email: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
-- name: Docker | postinstall-Debian.yml
+- include_tasks: postinstall-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Ensure Docker is started and enabled at boot.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,22 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Docker | Configure Proxy - Ubuntu systemd
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
+  blockinfile:
+    path: /lib/systemd/system/docker.service
+    insertafter: '^\[Service\]$'
+    content: |
+      Environment="HTTP_PROXY={{ docker_http_proxy }}"
+      Environment="HTTPS_PROXY={{ docker_http_proxy }}"
+      Environment="NO_PROXY={{ docker_no_proxy }}"
+
+- name: Docker | Log into DockerHub
+  docker_login:
+    username: "{{ docker_hub_username }}"
+    password: "{{ docker_hub_password }}"
+    email: "{{ docker_hub_email }}"
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,21 +8,8 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
-- name: Docker | Configure Proxy - Ubuntu systemd
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
-  blockinfile:
-    path: /lib/systemd/system/docker.service
-    insertafter: '^\[Service\]$'
-    content: |
-      Environment="HTTP_PROXY={{ docker_http_proxy }}"
-      Environment="HTTPS_PROXY={{ docker_http_proxy }}"
-      Environment="NO_PROXY={{ docker_no_proxy }}"
-
-- name: Docker | Log into DockerHub
-  docker_login:
-    username: "{{ docker_hub_username }}"
-    password: "{{ docker_hub_password }}"
-    email: "{{ docker_hub_email }}"
+- name: Docker | postinstall-Debian.yml
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure Docker is started and enabled at boot.
   service:

--- a/tasks/postinstall-Debian.yml
+++ b/tasks/postinstall-Debian.yml
@@ -1,0 +1,10 @@
+---
+- name: Docker | Configure Proxy - Ubuntu systemd
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
+  blockinfile:
+    path: /lib/systemd/system/docker.service
+    insertafter: '^\[Service\]$'
+    content: |
+      Environment="HTTP_PROXY={{ docker_http_proxy }}"
+      Environment="HTTPS_PROXY={{ docker_http_proxy }}"
+      Environment="NO_PROXY={{ docker_no_proxy }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -38,3 +38,27 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: yes
+
+- name: Docker | Configure Proxy - Ubuntu systemd
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
+  blockinfile:
+    path: /lib/systemd/system/docker.service
+    insertafter: '^\[Service\]$'
+    content: |
+      Environment="HTTP_PROXY={{ docker_http_proxy }}"
+      Environment="HTTPS_PROXY={{ docker_http_proxy }}"
+      Environment="NO_PROXY={{ docker_no_proxy }}"
+
+- name: Docker | Reload configuration
+  systemd:
+    name: docker
+    enabled: yes
+    masked: no
+    daemon_reload: yes
+    state: restarted
+
+- name: Docker | Log into DockerHub
+  docker_login:
+    username: "{{ docker_hub_username }}"
+    password: "{{ docker_hub_password }}"
+    email: "{{ docker_hub_email }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -38,27 +38,3 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: yes
-
-- name: Docker | Configure Proxy - Ubuntu systemd
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
-  blockinfile:
-    path: /lib/systemd/system/docker.service
-    insertafter: '^\[Service\]$'
-    content: |
-      Environment="HTTP_PROXY={{ docker_http_proxy }}"
-      Environment="HTTPS_PROXY={{ docker_http_proxy }}"
-      Environment="NO_PROXY={{ docker_no_proxy }}"
-
-- name: Docker | Reload configuration
-  systemd:
-    name: docker
-    enabled: yes
-    masked: no
-    daemon_reload: yes
-    state: restarted
-
-- name: Docker | Log into DockerHub
-  docker_login:
-    username: "{{ docker_hub_username }}"
-    password: "{{ docker_hub_password }}"
-    email: "{{ docker_hub_email }}"


### PR DESCRIPTION
fixing docker beyond proxy is paramount to install awx. This also close #36 . ATM only works on ubuntu > 16.04, it could be easily modified to support other systemd or init systems.