### PR TITLE
Fix device mapper issue for CentOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 docker_edition: 'ce'
 docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present
+docker_daemon_opts: {}
 
 # Docker Compose options.
 docker_install_compose: true
@@ -17,3 +18,4 @@ docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distrib
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo
 docker_yum_repo_enable_edge: 0
 docker_yum_repo_enable_test: 0
+docker_redhat_storage_driver: vfs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,18 @@
 - name: Install Docker.
   package: name={{ docker_package }} state={{ docker_package_state }}
 
+- name: Ensure Docker config dir exists
+  file:
+    path: /etc/docker
+    state: directory
+  when: docker_daemon_opts|length > 0
+
+- name: Configure Docker daemon
+  template:
+    src: daemon.json.j2
+    dest: /etc/docker/daemon.json
+  when: docker_daemon_opts|length > 0
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,3 +34,8 @@
     section: 'docker-{{ docker_edition }}-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
+
+- name: Configure default docker storage-driver for RedHat.
+  set_fact:
+    docker_daemon_opts: "{{docker_daemon_opts|combine( {'storage-driver': '{{ docker_redhat_storage_driver }}' } )}}"
+  when: "'storage-driver' not in docker_daemon_opts"

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,0 +1,1 @@
+{{ docker_daemon_opts | to_nice_json }}


### PR DESCRIPTION
There is an error when applying this playbook to CentOS also mentioned here: https://github.com/geerlingguy/ansible-role-docker/issues/42

> TASK [ansible-role-docker-master : Ensure Docker is started and enabled at boot.] ***
> fatal: [jenkins-centos]: FAILED! => {"changed": false, "msg": "Unable to start service docker: Job for docker.service failed because the control process exited with error code. See \"systemctl status docker.service\" and \"journalctl -xe\" for details.\n"}

When I run `journalctl -xe` is shows true nature of this error: 
`Feb 15 15:28:24 jenkins-centos dockerd[543]: time="2018-02-15T15:28:24.157471194 Z" level=error msg="There are no more loopback devices available."`

After small investigation (ex. [here](https://github.com/rancher/docker-from-scratch/issues/20)) it becomes clear that we need to change default docker storage driver for CentOS. 

Suggested fix for this problem:
1. Introduce `docker_daemon_opts` var to allow demon configuration
2. Introduce default value for storage driver to be used for RedHat via `docker_redhat_storage_driver` (I used vfs, but feel free to suggest other)
3. Added conditional step that applied default storage driver for RedHat if it is not set explicitly via `docker_daemon_opts`
4. Added conditional step that created docker configuration file if `docker_daemon_opts` not empty