### PR TITLE
Make ignoring repository key error optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ docker_compose_path: /usr/local/bin/docker-compose
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
 docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_ignore_key_error: true
 
 # Used only for RedHat/CentOS.
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -21,7 +21,7 @@
     id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     state: present
   register: add_repository_key
-  ignore_errors: true
+  ignore_errors: "{{ docker_apt_ignore_key_error }}"
 
 - name: Ensure curl is present (on older systems without SNI).
   package: name=curl state=present


### PR DESCRIPTION
Just ignoring an error regarding the Docker GPG key and downloading it
from "some" web page is not desired in any environment.
