### PR TITLE
make adding the Docker repo optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present
 docker_restart_on_package_change: True
 
+# Add Docker repo
+docker_add_repository: true
+
 # Docker Compose options.
 docker_install_compose: True
 docker_compose_version: "1.21.1"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,26 +15,28 @@
     - apt-transport-https
     - ca-certificates
 
-- name: Add Docker apt key.
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-    state: present
-  register: add_repository_key
-  ignore_errors: "{{ docker_apt_ignore_key_error }}"
+- block:
+   - name: Add Docker apt key.
+     apt_key:
+       url: https://download.docker.com/linux/ubuntu/gpg
+       id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+       state: present
+     register: add_repository_key
+     ignore_errors: "{{ docker_apt_ignore_key_error }}"
 
-- name: Ensure curl is present (on older systems without SNI).
-  package: name=curl state=present
-  when: add_repository_key is failed
+   - name: Ensure curl is present (on older systems without SNI).
+     package: name=curl state=present
+     when: add_repository_key is failed
 
-- name: Add Docker apt key (alternative for older systems without SNI).
-  shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
-  args:
-    warn: no
-  when: add_repository_key is failed
+   - name: Add Docker apt key (alternative for older systems without SNI).
+     shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+     args:
+       warn: no
+     when: add_repository_key is failed
 
-- name: Add Docker repository.
-  apt_repository:
-    repo: "{{ docker_apt_repository }}"
-    state: present
-    update_cache: yes
+   - name: Add Docker repository.
+     apt_repository:
+       repo: "{{ docker_apt_repository }}"
+       state: present
+       update_cache: yes
+  when: docker_add_repository

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -8,29 +8,32 @@
     - docker-common
     - docker-engine
 
-- name: Add Docker GPG key.
-  rpm_key:
-    key: https://download.docker.com/linux/centos/gpg
-    state: present
+- block:
+  - name: Add Docker GPG key.
+    rpm_key:
+      key: https://download.docker.com/linux/centos/gpg
+      state: present
 
-- name: Add Docker repository.
-  get_url:
-    url: "{{ docker_yum_repo_url }}"
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    owner: root
-    group: root
-    mode: 0644
+  - name: Add Docker repository.
+    get_url:
+      url: "{{ docker_yum_repo_url }}"
+      dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+      owner: root
+      group: root
+      mode: 0644
 
-- name: Configure Docker Edge repo.
-  ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    section: 'docker-{{ docker_edition }}-edge'
-    option: enabled
-    value: '{{ docker_yum_repo_enable_edge }}'
+  - name: Configure Docker Edge repo.
+    ini_file:
+      dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+      section: 'docker-{{ docker_edition }}-edge'
+      option: enabled
+      value: '{{ docker_yum_repo_enable_edge }}'
 
-- name: Configure Docker Test repo.
-  ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    section: 'docker-{{ docker_edition }}-test'
-    option: enabled
-    value: '{{ docker_yum_repo_enable_test }}'
+  - name: Configure Docker Test repo.
+    ini_file:
+      dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+      section: 'docker-{{ docker_edition }}-test'
+      option: enabled
+      value: '{{ docker_yum_repo_enable_test }}'
+
+  when: docker_add_repository


### PR DESCRIPTION
- organize the repo actions in one block
- make adding the Docker repo optional, which you might not want when using a local Satellite-managed repo