### PR TITLE
Fix 'using tests as filters' deprecation warning

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -25,13 +25,13 @@
 
 - name: Ensure curl is present (on older systems without SNI).
   package: name=curl state=present
-  when: add_repository_key|failed
+  when: add_repository_key is failed
 
 - name: Add Docker apt key (alternative for older systems without SNI).
   shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
   args:
     warn: no
-  when: add_repository_key|failed
+  when: add_repository_key is failed
 
 - name: Add Docker repository.
   apt_repository:


### PR DESCRIPTION
Fixes these warnings by heeding the advice.

```
TASK [geerlingguy.docker : Ensure curl is present (on older systems without SNI).] *************************************************
Friday 11 May 2018  09:08:15 -0400 (0:00:02.128)       0:02:28.194 ************ 
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` instead use `result is failed`. This 
feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [geerlingguy.docker : Add Docker apt key (alternative for older systems without SNI).] ****************************************
Friday 11 May 2018  09:08:15 -0400 (0:00:00.067)       0:02:28.261 ************ 
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` instead use `result is failed`. This 
feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```