### PR TITLE
Fix version pinning format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below, along with default values (see `defaults/m
     docker_package: "docker-{{ docker_edition }}"
     docker_package_state: present
 
-The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using a format like `docker-{{ docker_edition }}-<VERSION>`. And you can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively.
+The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using a format like `docker-{{ docker_edition }}=<VERSION>`. And you can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively.
 
     docker_restart_on_package_change: True
 


### PR DESCRIPTION
I had to use `=` to get it to work in Ubuntu. I'm not sure if different distributions may behave differently here.