### PR TITLE
Fix docker_users conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,4 +25,4 @@
   when: docker_install_compose
 
 - include_tasks: docker-users.yml
-  when: docker_users
+  when: docker_users is defined


### PR DESCRIPTION
When defining users in the docker_users var, an error occurs about evaluating the docker_users conditional. This change will fix the error