### PR TITLE
Version tag must be `=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below, along with default values (see `defaults/m
     docker_package: "docker-{{ docker_edition }}"
     docker_package_state: present
 
-The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using a format like `docker-{{ docker_edition }}-<VERSION>`. And you can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
+The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using a format like `docker-{{ docker_edition }}=<VERSION>`. And you can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
     docker_service_state: started
     docker_service_enabled: yes


### PR DESCRIPTION
Version tag must be `=` 

because `-` give an error.

TASK [geerlingguy.docker : Install Docker.] ************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "No package matching 'docker-ce-17.12.0-ce-0~ubuntu' is available"}