### PR TITLE
adding docker_yum_repo_extra variable for resolving issue in RPM based operating systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Docker Compose installation options.
 
 (Used only for RedHat/CentOS.) You can enable the Edge or Test repo by setting the respective vars to `1`.
 
+    docker_yum_repo_extra: rhel-7-server-extras-rpms
+
+(Used only for RedHat/CentOS.) Enable the extras RHEL repository. This ensures access to the `container-selinux` package which is required by docker.
+The repository can differ per your architecture, operating system/distribution and cloud provider, so review the options in this step before running:
+
+- `rhel-7-server-extras-rpms` - For all architectures except IBM Power
+- `rhui-REGION-rhel-server-extras` - For AWS (where REGION is a literal, and does not represent the region your machine is running in)
+- `rhui-rhel-7-server-rhui-extras-rpms` - For Azure
+- `ol7_addons` - For Oracle Linux
+
+> __NOTE__ Also you can specify another repository depending your operating system, architecture, preference, or something else.
+
+Alternately, obtain that package manually from Red Hat. There is no way to publicly browse this repository.
+
     docker_users:
       - user1
       - user2

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,3 +34,20 @@
     section: 'docker-{{ docker_edition }}-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
+
+- name: Configure Extra repo
+  block:
+    - name: Get the extra repo file
+      shell: grep '\[{{ docker_yum_repo_extra }}\]' /etc/yum.repos.d/*.repo | awk -F ":" '{print $1}'
+      register: extra_repo_file
+      check_mode: no
+      changed_when: no
+
+    - name: Enable the extras RHEL repository. This ensures access to the container-selinux package.
+      ini_file:
+        dest: '/etc/yum.repos.d/{{ extra_repo_file.stdout }}'
+        section: '{{ docker_yum_repo_extra }}'
+        option: enabled
+        value: 1
+      when: extra_repo_file.stderr != ""
+  when: docker_yum_repo_extra is defined


### PR DESCRIPTION
There is an fix of docker dependency error on RHEL: #56 

I have same problem in Oracle Linux. See [Docker Documentation](https://docs.docker.com/install/linux/docker-ee/rhel/#set-up-the-repository) (5th step).

So I think `container-selinux` package should be installed, probably extras repo should be enabled.

About Amazon Linux AMI... he are have own installation instructions, and I can implement it. if someone open the issue.

## Suggested fix for this problem:

Introduce `docker_yum_repo_extra` var which enables the extras RHEL repository. This ensures access to the `container-selinux` package which is required by docker.

By default this variable not defined, and it is an optional.
 