### PR TITLE
Fix RHEL 7 dependency on container-selinux

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,3 +34,10 @@
     section: 'docker-{{ docker_edition }}-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
+
+- name: Install container-selinux package (Dependency)
+  yum:
+    name: container-selinux
+    state: present
+    enablerepo: rhel-7-server-extras-rpms
+  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'


### PR DESCRIPTION
Fixes #56 

Proposed fix is to install the dependency only on RHEL 7 and without globally enabling the extras repo. It's enable only while installing the package via the "enablerepo" yum option.