### PR TITLE
Update apt-cache before installing missing docker dependencies

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,6 +12,7 @@
       - apt-transport-https
       - ca-certificates
     state: present
+    update-cache: true
 
 - name: Add Docker apt key.
   apt_key:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -37,3 +37,5 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: true
+    cache_valid_time: 3600
+


### PR DESCRIPTION
Fix #117 
Update cache before installing missing dependencies