### PR TITLE
Add support for checksum validation of downloaded docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Variables to control the state of the `docker` service, and whether it should st
 
     docker_install_compose: true
     docker_compose_version: "1.22.0"
+    docker_compose_checksum: "sha256:4d618e19b91b9a49f36d041446d96a1a0a067c676330a4f25aca6bbd000de7a9"
     docker_compose_path: /usr/local/bin/docker-compose
 
 Docker Compose installation options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ docker_restart_handler_state: restarted
 # Docker Compose options.
 docker_install_compose: true
 docker_compose_version: "1.22.0"
+docker_compose_checksum: "sha256:f679a24b93f291c3bffaff340467494f388c0c251649d640e661d509db9d57e9"
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -17,4 +17,5 @@
   get_url:
     url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
     dest: "{{ docker_compose_path }}"
+    checksum: "{{ docker_compose_checksum | default(omit) }}"
     mode: 0755


### PR DESCRIPTION
Might be a good idea to validate the downloaded version of docker-compose?