### PR TITLE
Skip empty item on docker_users

### DIFF
--- a/tasks/docker-users.yml
+++ b/tasks/docker-users.yml
@@ -5,3 +5,4 @@
     groups: docker
     append: true
   with_items: "{{ docker_users }}"
+  when: item != ''


### PR DESCRIPTION
I wrote a playbook that had something like this:
```
docker_users:
  - "{{ lookup('env','USER') }}"
```
which might return an empty string if running it from inside a container. I noticed ansible-role-docker failed on attempt to add an user with empty name in the docker group. Later I refactory my code to deal with this scenario but I think that It could be avoided by adding a guard on ansible-role-docker directly, once the above code pattern might be often used out there.