### PR TITLE
adds ansible version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Ansible Role that installs [Docker](https://www.docker.com) on Linux.
 
 ## Requirements
 
-None.
+- Ansible 2.4+
 
 ## Role Variables
 


### PR DESCRIPTION
This role uses both `include_tasks` and `import_tasks`, both of which require Ansible 2.4.