### PR TITLE
Fixes deprecation warnings about evaluating bare variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   meta: flush_handlers
 
 - include_tasks: docker-compose.yml
-  when: docker_install_compose
+  when: docker_install_compose | bool
 
 - include_tasks: docker-users.yml
-  when: docker_users
+  when: docker_users | bool


### PR DESCRIPTION
Fix for the following 2 deprecation warnings under Ansible 2.8:

```sh
[DEPRECATION WARNING]: evaluating docker_install_compose as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: evaluating docker_users as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```