### PR TITLE
Fix "Permission denied" error when installing deps

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,6 +7,7 @@
     state: absent
 
 - name: Ensure dependencies are installed.
+  become: true
   apt:
     name:
       - apt-transport-https


### PR DESCRIPTION
This fixes the following error when trying to use this role on `Ubuntu 18.04`:

```
fatal: [jenkins_master]: FAILED! => {
   "changed":false,
   "msg":"'/usr/bin/apt-mark manual apt-transport-https ca-certificates' failed: E: Could not create temporary file for /var/lib/apt/extended_states - mkstemp (13: Permission denied)\nE: Failed to write temporary StateFile /var/lib/apt/extended_states\n",
   "rc":100,
   "stderr":"E: Could not create temporary file for /var/lib/apt/extended_states - mkstemp (13: Permission denied)\nE: Failed to write temporary StateFile /var/lib/apt/extended_states\n",
   "stderr_lines":[
      "E: Could not create temporary file for /var/lib/apt/extended_states - mkstemp (13: Permission denied)",
      "E: Failed to write temporary StateFile /var/lib/apt/extended_states"
   ],
   "stdout":"apt-transport-https was already set to manually installed.\nca-certificates set to manually installed.\n",
   "stdout_lines":[
      "apt-transport-https was already set to manually installed.",
      "ca-certificates set to manually installed."
   ]
}
```