### PR TITLE
make sure yum isn't turning off docker's network

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -33,3 +33,10 @@
     section: 'docker-{{ docker_edition }}-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
+
+- name: Set net.ipv4.ip_forward 1
+  sysctl:
+    name: "net.ipv4.ip_forward"
+    sysctl_set: "yes"
+    value: 1
+~                                            


### PR DESCRIPTION
Docker relies on the `systemctl` setting `net.ipv4.ip_forward = 1` to give containers access to networks outside the instance. In centos, this setting seems to be on by  default, so every instance has it when it starts up and docker can talk to the world and everything is awesome. But for some reason the `/etc/rc.d/init.d/network` does `sysctl -w net.ipv4.ip_forward=0 > /dev/null 2>&1` when `stop` is called, which it appears to be during some yum updates. This setting never gets changed back to 1 until a reboot occurs, and docker containers lose the ability to talk outside the instance.