### PR TITLE
Add the distro to the platform.name so that it appears in the ansible logs

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint:
   options:
     config-file: molecule/default/yaml-lint.yml
 platforms:
-  - name: instance
+  - name: instance-${MOLECULE_DISTRO:-centos7}
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:


### PR DESCRIPTION
Learning some great stuff from you, Jeff.

Here's a little improvement I liked.

## Before

```
TASK [geerlingguy.docker : Install Docker.] **********************************
    ok: [instance] => changed=false 
```
## After

```
TASK [geerlingguy.docker : Install Docker.] **********************************
    ok: [instance-centos7] => changed=false 
```

![Screenshot from 2019-10-17 02-36-23](https://user-images.githubusercontent.com/106420/66983627-fd738100-f086-11e9-851e-bab247832e7e.png)
