### PR TITLE
Apt pin docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Docker Compose installation options.
     docker_apt_arch: amd64
     docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     docker_apt_ignore_key_error: True
+    docker_apt_version: "5:18.09"
 
-(Used only for Debian/Ubuntu.) You can switch the channel to `edge` if you want to use the Edge release.
+(Used only for Debian/Ubuntu.) You can switch the channel to `edge` if you want to use the Edge release. If you need to pin the docker version you can set docker_apt_version. It defaults to the latest available though.
 
     docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo
     docker_yum_repo_enable_edge: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
-docker_apt_version:
+docker_apt_version: ''
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-{{ docker_edition }}.repo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ docker_restart_handler_state: restarted
 
 # Docker Compose options.
 docker_install_compose: true
-docker_compose_version: "1.22.0"
+docker_compose_version: "1.24.1"
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ docker_restart_handler_state: restarted
 
 # Docker Compose options.
 docker_install_compose: true
-docker_compose_version: "1.24.1"
+docker_compose_version: "1.22.0"
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
@@ -19,6 +19,7 @@ docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
+docker_apt_version:
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-{{ docker_edition }}.repo

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -38,3 +38,9 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: true
+
+- name: Add Docker apt preferences file to pin a version.
+  template:
+    src: apt-preferences-docker.j2
+    dest: /etc/apt/preferences.d/docker
+  when: docker_apt_version | length > 0

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -43,4 +43,5 @@
   template:
     src: apt-preferences-docker.j2
     dest: /etc/apt/preferences.d/docker
-  when: docker_apt_version | length > 0
+  when: docker_apt_version is defined and
+        docker_apt_version | length > 0

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -43,5 +43,4 @@
   template:
     src: apt-preferences-docker.j2
     dest: /etc/apt/preferences.d/docker
-  when: docker_apt_version is defined and
-        docker_apt_version | length > 0
+  when: docker_apt_version is defined and not empty

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -43,4 +43,4 @@
   template:
     src: apt-preferences-docker.j2
     dest: /etc/apt/preferences.d/docker
-  when: docker_apt_version is defined and not empty
+  when: docker_apt_version | length > 0

--- a/templates/apt-preferences-docker.j2
+++ b/templates/apt-preferences-docker.j2
@@ -1,0 +1,7 @@
+Package: {{ docker_package }}
+Pin: version {{ docker_apt_version }}.*
+Pin-Priority: 1000
+
+Package: {{ docker_package }}-cli
+Pin: version {{ docker_apt_version }}.*
+Pin-Priority: 1000


### PR DESCRIPTION
I needed to pin the version of docker permanently for use with kubernetes. I have added a feature to do that via apt.

Related issues: #162 #45 #85