### PR TITLE
Pull GPG key from a different source (Debian/Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Docker Compose installation options.
 
     docker_apt_release_channel: stable
     docker_apt_arch: amd64
-    docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+    docker_apt_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+    docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     docker_apt_ignore_key_error: True
 
 (Used only for Debian/Ubuntu.) You can switch the channel to `edge` if you want to use the Edge release.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,8 @@ docker_compose_path: /usr/local/bin/docker-compose
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 
 # Used only for RedHat/CentOS/Fedora.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,7 +15,7 @@
 
 - name: Add Docker apt key.
   apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
+    url: "{{ docker_apt_key }}"
     id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     state: present
   register: add_repository_key
@@ -28,7 +28,7 @@
 - name: Add Docker apt key (alternative for older systems without SNI).
   shell: |
     set -o pipefail
-    curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    curl -sSL {{ docker_apt_key }} | sudo apt-key add -
   args:
     warn: false
   when: add_repository_key is failed


### PR DESCRIPTION
Even though, Docker's GPG key for Debian and Ubuntu is exactly the same, accordingly to Docker official documentation the URL is different:

**Debian**

![image](https://user-images.githubusercontent.com/2049686/68175151-49ab3600-ff4e-11e9-91a2-f4fed58cb1cd.png)

https://docs.docker.com/install/linux/docker-ce/debian/

**Ubuntu**

![image](https://user-images.githubusercontent.com/2049686/68175191-66e00480-ff4e-11e9-92be-a8ee86509b7d.png)

https://docs.docker.com/install/linux/docker-ce/ubuntu/

This PR change APT GPG key URL depending on the distribution (Debian or Ubuntu) just for the sake of consistency, following the steps described in the official documentation.