### PR TITLE
Fix value type warning during repo configure

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,8 +22,8 @@ docker_apt_ignore_key_error: true
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-{{ docker_edition }}.repo
-docker_yum_repo_enable_edge: 0
-docker_yum_repo_enable_test: 0
+docker_yum_repo_enable_edge: "0"
+docker_yum_repo_enable_test: "0"
 
 # A list of users who will be added to the docker group.
 docker_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
 docker_edition: 'ce'
-docker_package: "docker-{{ docker_edition }}"
+docker_package: 'docker-{{ docker_edition }}'
 docker_package_state: present
 
 # Service options.
@@ -11,19 +11,19 @@ docker_restart_handler_state: restarted
 
 # Docker Compose options.
 docker_install_compose: true
-docker_compose_version: "1.24.1"
+docker_compose_version: '1.24.1'
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: 'deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}'
 docker_apt_ignore_key_error: true
 
 # Used only for RedHat/CentOS/Fedora.
-docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-{{ docker_edition }}.repo
-docker_yum_repo_enable_edge: "0"
-docker_yum_repo_enable_test: "0"
+docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo
+docker_yum_repo_enable_edge: '0'
+docker_yum_repo_enable_test: '0'
 
 # A list of users who will be added to the docker group.
 docker_users: []


### PR DESCRIPTION
Simple fix which allows to avoid the following warning message: "[WARNING]: The value 0 (type int) in a string field was converted to u'0' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change."