### PR TITLE
docs: update docker_compose_version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can control whether the package is installed, uninstalled, or at the latest 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
 
     docker_install_compose: true
-    docker_compose_version: "1.22.0"
+    docker_compose_version: "1.24.1"
     docker_compose_path: /usr/local/bin/docker-compose
 
 Docker Compose installation options.


### PR DESCRIPTION
The `docker_compose_version` default value was updated from 1.22.0 to 1.24.1 in #155, but the documentation in README.md was not updated accordingly.