### PR TITLE
Add the possibility to customize the options in '/etc/docker/daemon.json'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using the distribution-specific format: Red Hat/CentOS: `docker-{{ docker_edition }}-<VERSION>`; Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>`.
 
-You can customize `daemon configuration` by providing `daemon.json` values in yaml format. Example:
+You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
-    docker_config_options:
+    docker_service_state: started
+    docker_service_enabled: true
+    docker_restart_handler_state: restarted
+
+You can customize `daemon configuration` by providing `daemon.json` values in yaml format. [List of available docker configuration options](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file#daemon-configuration-file). You can also use [online JsonToYaml tool](https://www.json2yaml.com) to convert them to yaml format. Example:
+
+    docker_daemon_json_options:
       exec-opts:
         - native.cgroupdriver=systemd
       log-driver: journald
       max-concurrent-downloads: 7
       max-concurrent-uploads: 5
       storage-driver: overlay2
-
-You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
-
-    docker_service_state: started
-    docker_service_enabled: true
-    docker_restart_handler_state: restarted
 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using the distribution-specific format: Red Hat/CentOS: `docker-{{ docker_edition }}-<VERSION>`; Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>`.
 
+You can customize `daemon configuration` by providing `daemon.json` values in yaml format. Example:
+
+    docker_config_options:
+      exec-opts:
+        - native.cgroupdriver=systemd
+      log-driver: journald
+      max-concurrent-downloads: 7
+      max-concurrent-uploads: 5
+      storage-driver: overlay2
+
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
     docker_service_state: started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,11 @@ docker_service_state: started
 docker_service_enabled: true
 docker_restart_handler_state: restarted
 
+# Docker config options.
+docker_config_options:
+  max-concurrent-downloads: 5
+  max-concurrent-uploads: 5
+
 # Docker Compose options.
 docker_install_compose: true
 docker_compose_version: "1.25.4"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,7 @@ docker_service_enabled: true
 docker_restart_handler_state: restarted
 
 # Docker config options.
-docker_config_options:
-  max-concurrent-downloads: 5
-  max-concurrent-uploads: 5
+docker_daemon_json_options: []
 
 # Docker Compose options.
 docker_install_compose: true

--- a/tasks/docker-daemon-options.yml
+++ b/tasks/docker-daemon-options.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure /etc/docker exists
+  file:
+    path: /etc/docker
+    state: directory
+
+- name: Install daemon.json
+  template:
+    src: docker-daemon.json.j2
+    dest: /etc/docker/daemon.json
+  notify: restart docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,17 @@
     state: "{{ docker_package_state }}"
   notify: restart docker
 
+- name: Ensure /etc/docker exists
+  file:
+    path: /etc/docker
+    state: directory
+
+- name: Install daemon.json
+  template:
+    src: docker-daemon.json.j2
+    dest: /etc/docker/daemon.json
+  notify: restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,16 +11,10 @@
     state: "{{ docker_package_state }}"
   notify: restart docker
 
-- name: Ensure /etc/docker exists
-  file:
-    path: /etc/docker
-    state: directory
-
-- name: Install daemon.json
-  template:
-    src: docker-daemon.json.j2
-    dest: /etc/docker/daemon.json
-  notify: restart docker
+- include_tasks: docker-daemon-options.yml
+  when:
+    - docker_daemon_json_options is defined
+    - docker_daemon_json_options | length > 0
 
 - name: Ensure Docker is started and enabled at boot.
   service:

--- a/templates/docker-daemon.json.j2
+++ b/templates/docker-daemon.json.j2
@@ -1,1 +1,1 @@
-{{ docker_config_options | default([])| to_nice_json }}
+{{ docker_daemon_json_options | default([]) | to_nice_json }}

--- a/templates/docker-daemon.json.j2
+++ b/templates/docker-daemon.json.j2
@@ -1,0 +1,1 @@
+{{ docker_config_options | default([])| to_nice_json }}


### PR DESCRIPTION
Hello,
This PR implement the possibility to provide `daemon.json` options in yaml format.
Handy for various customizations.

Please review,
Thank you!
