### PR TITLE
feat: install docker-compose via control node download

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -5,16 +5,28 @@
   changed_when: false
   failed_when: false
 
-- name: Delete existing docker-compose version if it's different.
-  file:
-    path: "{{ docker_compose_path }}"
-    state: absent
+- name: Download and Install Docker Compose
+  block:
+  - name: Download Docker Compose (if configured).
+    get_url:
+      url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
+      dest: "/tmp/docker-compose-Linux-x86_64-{{ docker_compose_version }}"
+      mode: 0755
+    register: _download_composer
+    until: _download_composer is succeeded
+    retries: 5
+    delay: 2
+    delegate_to: localhost
+  - name: Install Docker Compose
+    copy:
+      src: "/tmp/docker-compose-Linux-x86_64-{{ docker_compose_version }}"
+      dest: "{{ docker_compose_path }}"
+      mode: 0755
+      owner: root
+      group: root
   when: >
-    docker_compose_current_version.stdout is defined
-    and docker_compose_version not in docker_compose_current_version.stdout
+    docker_compose_current_version.stdout is undefined
+    or docker_compose_version not in docker_compose_current_version.stdout
 
-- name: Install Docker Compose (if configured).
-  get_url:
-    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
-    dest: "{{ docker_compose_path }}"
-    mode: 0755
+
+


### PR DESCRIPTION
This change will download docker-compose from github to the control node and afterwards upload it to the managed server. This is important because servers should not be able to access github.
 
Changes:
* remove delete operation since it is not required with this implementation anymore
* download docker-compose to control node and upload it to the managed server if no version or a version mismatch is detected