### PR TITLE
Adding option to login to private docker registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Usually in combination with changing `docker_yum_repository` as well.
       - user2
 
 A list of system users to be added to the `docker` group (so they can use Docker on the server).
+    
+    docker_logins:
+      - url: repository.example.com
+        username: myuser
+        password: mypass
+
+A list of private container registries to be logged in with `docker`.
 
 ## Use with Ansible (and `docker` Python library)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,6 @@ docker_yum_gpg_key: https://download.docker.com/linux/centos/gpg
 
 # A list of users who will be added to the docker group.
 docker_users: []
+
+# A list of private repositories and login credentials
+docker_logins: []

--- a/tasks/docker-login.yml
+++ b/tasks/docker-login.yml
@@ -1,0 +1,10 @@
+---
+- name: Check if credentials exist and are authorized
+  command: timeout 5 docker login {{ docker_login.url }}
+  register: docker_login_check
+  changed_when: false
+  failed_when: docker_login_check.rc not in (0, 124) # 124 is timeout exceeded code
+
+- name: Login to registry {{ docker_login.url }} as {{ docker_login.username }}
+  shell: docker login --username {{ docker_login.username }} --password {{ docker_login.password }} {{ docker_login.url }} 2>/dev/null
+  when: docker_login_check.rc == 124

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,10 @@
 
 - include_tasks: docker-users.yml
   when: docker_users | length > 0
+
+- include_tasks: docker-login.yml
+  loop: "{{ docker_logins }}"
+  loop_control:
+    loop_var: docker_login
+  when: docker_logins | length > 0
+


### PR DESCRIPTION
This PR allows logging in to private docker registries, after docker has been installed.
Here is an example how user would login:
```yaml
docker_logins:
  - url: repository.example.com
    username: myuser
    password: mypass
```