### PR TITLE
Change default docker compose version to 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can control whether the package is installed, uninstalled, or at the latest 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
 
     docker_install_compose: true
-    docker_compose_version: "1.25.4"
+    docker_compose_version: "1.26.0"
     docker_compose_path: /usr/local/bin/docker-compose
 
 Docker Compose installation options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ docker_restart_handler_state: restarted
 
 # Docker Compose options.
 docker_install_compose: true
-docker_compose_version: "1.25.4"
+docker_compose_version: "1.26.0"
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.


### PR DESCRIPTION
Changed docker compose version to the latest release 1.26.0: https://github.com/docker/compose/releases

Closes #208 