### PR TITLE
Add ability to look up the latest docker-compose version from Github API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Variables to control the state of the `docker` service, and whether it should st
     docker_compose_version: "1.26.0"
     docker_compose_path: /usr/local/bin/docker-compose
 
-Docker Compose installation options.
+Docker Compose installation options. You can use `docker_compose_version: "latest"` to get the current latest version.
 
     docker_apt_release_channel: stable
     docker_apt_arch: amd64

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -16,7 +16,7 @@
 
     - name: Set latest version in docker_compose_version variable
       set_fact:
-        docker_compose_version: "{{url_content.json.name }}"
+        docker_compose_version: "{{ url_content.json.name }}"
   when: docker_compose_version == 'latest'
 
 - name: Delete existing docker-compose version if it's different.

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -5,6 +5,20 @@
   changed_when: false
   failed_when: false
 
+- name: Get latest version from docker-compose (if configured)
+  block:
+    - name: Get latest version of docker-compose from Github API
+      uri:
+        url: https://api.github.com/repos/docker/compose/releases/latest
+        return_content: yes
+      register: url_content
+      delegate_to: localhost
+
+    - name: Set latest version in docker_compose_version variable
+      set_fact:
+        docker_compose_version: "{{url_content.json.name }}"
+  when: docker_compose_version == 'latest'
+
 - name: Delete existing docker-compose version if it's different.
   file:
     path: "{{ docker_compose_path }}"


### PR DESCRIPTION
This small changes add the ability to get the latest docker-compose version from Github API when docker_compose_version is "latest"