### PR TITLE
setup-RedHat.yml - Remove podman-manpages for centos-8.1

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,6 +7,13 @@
       - docker-engine
     state: absent
 
+# See https://github.com/containers/podman/issues/4791
+- name: Remove conflicting podman-manpages (conflits with docker on CentOS 8.1)
+  package:
+    name: podman-manpages
+    state: absent
+  when: ansible_distribution == "CentOS" and ansible_distribution_version == "8.1"
+
 - name: Add Docker GPG key.
   rpm_key:
     key: "{{ docker_yum_gpg_key }}"


### PR DESCRIPTION
On CentOS-8.1, docker installation conflicts with podman-manpages -
see https://github.com/containers/podman/issues/4791.

Add a workaround which removes podman-manpages for CentOS 8.1.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@email.com>