### PR TITLE
Allow setting of /etc/docker/daemon.json through this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Usually in combination with changing `docker_apt_repository` as well.
 You can change `docker_yum_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror.
 Usually in combination with changing `docker_yum_repository` as well.
 
+    docker_daemon_json:
+      exec-opts:
+        - native.cgroupdriver=systemd
+      log-driver: json-file
+      log-opts:
+        max-size: "100m"
+      storage-driver: overlay2
+
+    docker_daemon_json_filename: /etc/docker/daemon.json
+
+Customize your /etc/docker/daemon.json contents and filename. The YAML passed to `docker_daemon_json` is converted
+to JSON and ends up at the location referred to by `docker_daemon_json_filename`. If you leave `docker_daemon_json`
+empty, no file will be created and `docker_daemon_json_filename` will be deleted, if it exists.
+
     docker_users:
       - user1
       - user2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,7 @@ docker_yum_gpg_key: https://download.docker.com/linux/centos/gpg
 
 # A list of users who will be added to the docker group.
 docker_users: []
+
+# Optional Docker daemon.json configuration
+docker_daemon_json: {}
+docker_daemon_json_filename: /etc/docker/daemon.json

--- a/molecule/daemon_json/converge.yml
+++ b/molecule/daemon_json/converge.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+    - name: Wait for systemd to complete initialization.  # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
+  roles:
+    - role: geerlingguy.docker
+      vars:
+        docker_daemon_json:
+          exec-opts:
+            - native.cgroupdriver=systemd
+          log-driver: json-file
+          log-opts:
+            max-size: "100m"
+          storage-driver: overlay2

--- a/molecule/daemon_json/molecule.yml
+++ b/molecule/daemon_json/molecule.yml
@@ -1,0 +1,23 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+verifier:
+  name: ansible

--- a/molecule/daemon_json/verify.yml
+++ b/molecule/daemon_json/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check for existence of daemon.json file
+      stat:
+        path: /etc/docker/daemon.json

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,14 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check for existence of daemon.json file
+      stat:
+        path: /etc/docker/daemon.json
+      register: daemon_json_st
+
+    - name: Fail if the daemon.json was found since it wasn't specified
+      assert:
+        that: "{{ not daemon_json_st.stat.exists }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,25 @@
     state: "{{ docker_package_state }}"
   notify: restart docker
 
+- name: Install Docker daemon.json
+  copy:
+    content: "{{ docker_daemon_json | to_json }}"
+    dest: "{{ docker_daemon_json_filename }}"
+    mode: "0644"
+    owner: root
+    group: root
+  notify: restart docker
+  when:
+    - "docker_daemon_json|bool"
+
+- name: Clean out Docker daemon.json
+  file:
+    path: "{{ docker_daemon_json_filename }}"
+    state: absent
+  when:
+    - "not docker_daemon_json|bool"
+    - "docker_daemon_json_filename|length > 0"
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker


### PR DESCRIPTION
Hi,

I would like to submit this PR to allow this role to deposit a /etc/docker/daemon.json file. I've been using this role for a little while and am creating the daemon.json file after the role has completed, meaning I have a chance of restarting Docker in the role and then again from edits/creation of daemon.json and that doesn't seem very efficient :).

For once, I've remembered to update the README.md in one of my PRs, so it should have a little description for you to refer to on what variables were added and what my intent is for how they should work.

Please let me know if you have any questions/concerns.

Thanks.