### PR TITLE
Added a long timeout for installing Docker package.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 docker_edition: 'ce'
 docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present
+docker_package_timeout: 1800
 
 # Service options.
 docker_service_state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,8 @@
   package:
     name: "{{ docker_package }}"
     state: "{{ docker_package_state }}"
+  async: "{{ docker_package_timeout }}"
+  poll: 5
   notify: restart docker
 
 - name: Ensure Docker is started and enabled at boot.


### PR DESCRIPTION
When running this on a slow internet connection, the package install can fail if it takes more than 5 minutes. Using async, it can be extended to allow a longer timeout to account for the slow speeds. Added a default variable value of 30 minutes which can be adjusted as needed.