### PR TITLE
Add a "docker system prune" cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
 script:
   # Run tests.
   - molecule test
+  - molecule test -s clean_up_job
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Usually in combination with changing `docker_yum_repository` as well.
 
 A list of system users to be added to the `docker` group (so they can use Docker on the server).
 
+    docker_clean_up_job: false
+    docker_clean_up_job_user: "{{ ansible_user_id }}"
+    docker_clean_up_job_schedule:
+      minute: "0"
+      hour: "0"
+      day: "*"
+      month: "*"
+      weekday: "0"
+
+Docker clean up task options. When `docker_clean_up_job` is set to `true` a cron job that runs the `docker system prune -af` command will be installed with the schedule defined in `docker_clean_up_job_schedule`.
+
 ## Use with Ansible (and `docker` Python library)
 
 Many users of this role wish to also use Ansible to then _build_ Docker images and manage Docker containers on the server where Docker is installed. In this case, you can easily add in the `docker` Python library using the `geerlingguy.pip` role:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,13 @@ docker_yum_gpg_key: https://download.docker.com/linux/centos/gpg
 
 # A list of users who will be added to the docker group.
 docker_users: []
+
+# Clean up cron job options.
+docker_clean_up_job: false
+docker_clean_up_job_user: "{{ ansible_user_id }}"
+docker_clean_up_job_schedule:
+  minute: "0"
+  hour: "0"
+  day: "*"
+  month: "*"
+  weekday: "0"

--- a/molecule/clean_up_job/converge.yml
+++ b/molecule/clean_up_job/converge.yml
@@ -1,0 +1,26 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+    - name: Wait for systemd to complete initialization.  # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
+
+  roles:
+    - role: geerlingguy.docker
+      vars:
+        docker_clean_up_job: true

--- a/molecule/clean_up_job/molecule.yml
+++ b/molecule/clean_up_job/molecule.yml
@@ -1,0 +1,23 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+verifier:
+  name: ansible

--- a/molecule/clean_up_job/verify.yml
+++ b/molecule/clean_up_job/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: Run crontab list command
+    - name: Run crontab list command  # noqa 301
       command: crontab -l
       register: crontab_list
 

--- a/molecule/clean_up_job/verify.yml
+++ b/molecule/clean_up_job/verify.yml
@@ -1,0 +1,11 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Run crontab list command
+      command: crontab -l
+      register: crontab_list
+
+    - name: Fail if the crontab entry is not found
+      assert:
+        that: "{{ '0 0 * * 0 docker system prune -af > /dev/null 2>&1' in crontab_list.stdout.split('\n') }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Run crontab list command
+      command: crontab -l
+      register: crontab_list
+      ignore_errors: true
+
+    - name: Fail if the crontab list command succeeds
+      assert:
+        that: "{{ crontab_list.rc != 0 }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: Run crontab list command
+    - name: Run crontab list command  # noqa 301
       command: crontab -l
       register: crontab_list
       ignore_errors: true

--- a/tasks/clean-up-job.yml
+++ b/tasks/clean-up-job.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure crontab is installed on 'RedHat' os family.
+  yum:
+    name: cronie
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure crontab is installed on 'Debian' os family.
+  apt:
+    name: cron
+  when: ansible_os_family == 'Debian'
+
+- name: Create Docker clean up cron job.
+  cron:
+    name: "docker disk clean up"
+    job: "docker system prune -af > /dev/null 2>&1"
+    minute: "{{ docker_clean_up_job_schedule.minute }}"
+    hour: "{{ docker_clean_up_job_schedule.hour }}"
+    day: "{{ docker_clean_up_job_schedule.day }}"
+    month: "{{ docker_clean_up_job_schedule.month }}"
+    weekday: "{{ docker_clean_up_job_schedule.weekday }}"
+    user: "{{ docker_clean_up_job_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,6 @@
 
 - include_tasks: docker-users.yml
   when: docker_users | length > 0
+
+- include_tasks: clean-up-job.yml
+  when: docker_clean_up_job | bool


### PR DESCRIPTION
Hi,
this pull request adds a clean up cron job that performs `docker system prune -af` on a regualr basis.
Please let me know if you have any questions or comments.
Thanks.