### PR TITLE
Update APT cache before installing the dependencies

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,6 +12,7 @@
       - apt-transport-https
       - ca-certificates
       - gnupg2
+    update_cache: yes
     state: present
 
 - name: Add Docker apt key.


### PR DESCRIPTION
On a clean installation (e.g. on AWS EC2), `apt update` needs to run first, otherwise the role fails with `No package matching 'gnupg2' is available`. To prevent this, let's force `apt` to update cache