### PR TITLE
replace arch to ansible variable

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -15,6 +15,6 @@
 
 - name: Install Docker Compose (if configured).
   get_url:
-    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
+    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-{{ ansible_architecture }}
     dest: "{{ docker_compose_path }}"
     mode: 0755


### PR DESCRIPTION
I would like to install docker-compose on arm64. Variables are fine, but `x86_64` string is not very flexible.