### PR TITLE
Added capabilty to configure docker/containerd root path & native cgroup 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,9 @@ docker_yum_gpg_key: https://download.docker.com/linux/centos/gpg
 
 # A list of users who will be added to the docker group.
 docker_users: []
+
+# configuration
+docker_default_config: true
+docker_root_path: ""
+containerd_root_path: ""
+docker_native_cgroup: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,19 @@
 
 - include_tasks: docker-users.yml
   when: docker_users | length > 0
+
+- name: Configure docker
+  template:
+    src: daemon.json.j2
+    dest: /etc/docker/daemon.json
+    mode: 0666
+  notify: restart docker
+  when: not docker_default_config
+
+- name: Configure containerd
+  template:
+    src: config.toml.j2
+    dest: /etc/containerd/config.toml
+    mode: 0666
+  notify: restart docker
+  when: not docker_default_config

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,0 +1,31 @@
+#   Copyright 2018-2020 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+disabled_plugins = ["cri"]
+
+root = "{{ containerd_root_path }}"
+#state = "/run/containerd"
+#subreaper = true
+#oom_score = 0
+
+#[grpc]
+#  address = "/run/containerd/containerd.sock"
+#  uid = 0
+#  gid = 0
+
+#[debug]
+#  address = "/run/containerd/debug.sock"
+#  uid = 0
+#  gid = 0
+#  level = "info"

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,0 +1,4 @@
+{
+	"data-root": "{{docker_root_path}}",
+    "exec-opts": ["native.cgroupdriver={{docker_native_cgroup}}"]
+}


### PR DESCRIPTION
Hi Jeff , thanks for sharing your role with community.

---
name: capabilty to configure docker/containerd root path
about: Configure docker daemon & native cgroup from cgroupfs to systemd 

---

**Describe the change**

Currently docker is installed using default root path for image/container storage.
But sometimes we need to save it in another place either for backup/snapshot or just size because you will install an orchestrator agent like kubelet for kubenetes on the node.
On the other hand, the default native cgroup cgroupfs is not recommended while using kubernetes:
https://kubernetes.io/docs/setup/production-environment/container-runtimes/

**Testing**
Molecule test provided
