### PR TITLE
Update cache before install gnupg2 package

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,10 +4,6 @@
   become: true
 
   pre_tasks:
-    - name: Update apt cache.
-      apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
-
     - name: Wait for systemd to complete initialization.  # noqa 303
       command: systemctl is-system-running
       register: systemctl_status

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,6 +13,7 @@
       - ca-certificates
       - gnupg2
     state: present
+    update_cache: true
 
 - name: Add Docker apt key.
   apt_key:


### PR DESCRIPTION
Hi!
Fixed error when in Debian-like systems used old cache

```
TASK [ansible-role-docker :  Ensure dependencies are installed.]
fatal: [instance]: FAILED! => {"changed": false, "msg": "No package matching 'gnupg2' is available"}

```
Added update cache before install packages 

