### PR TITLE
add update_cache for 'Ensure dependencies'

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,6 +13,7 @@
       - ca-certificates
       - gnupg2
     state: present
+    update_cache: yes
 
 - name: Add Docker apt key.
   apt_key:


### PR DESCRIPTION
```
TASK [geerlingguy.docker : Ensure dependencies are installed.] ****************************************************************************************************************************************************
Monday 08 February 2021  16:28:22 +0600 (0:00:02.650)       0:00:07.421 *******
fatal: [airflow]: FAILED! => {
    "cache_update_time": 1566305390,
    "cache_updated": false,
    "changed": false,
    "rc": 100
}

STDOUT:

Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  apt-transport-https gnupg2
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 6360 B of archives.
After this operation, 205 kB of additional disk space will be used.
Err:1 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 apt-transport-https all 1.6.11
  404  Not Found [IP: 91.189.88.142 80]
Ign:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 gnupg2 all 2.2.4-1ubuntu1.2
Err:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 gnupg2 all 2.2.4-1ubuntu1.2
  404  Not Found [IP: 91.189.88.142 80]



STDERR:

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/a/apt/apt-transport-https_1.6.11_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/g/gnupg2/gnupg2_2.2.4-1ubuntu1.2_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?



MSG:

'/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"      install 'apt-transport-https' 'gnupg2'' failed: E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/a/apt/apt-transport-https_1.6.11_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/g/gnupg2/gnupg2_2.2.4-1ubuntu1.2_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```