### PR TITLE
Ensure Podman and Buildah are not installed on RHEL-based systems

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,10 +1,12 @@
 ---
-- name: Ensure old versions of Docker are not installed.
+- name: Ensure Podman, Buildah and old versions of Docker are not installed.
   package:
     name:
       - docker
       - docker-common
       - docker-engine
+      - podman
+      - buildah
     state: absent
 
 - name: Add Docker GPG key.


### PR DESCRIPTION
Presence of buildah and podman creates version issue for runc and makes the role fail on fresh centos 8 installation.