### PR TITLE
add possibility to hold docker package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ docker_apt_arch: amd64
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_hold: false
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,29 @@
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Remove hold on docker
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  when: docker_apt_hold|default(false)|bool
+  with_items:
+  - docker-{{ docker_edition }}
+  - docker-{{ docker_edition }}-cli
+
 - name: Install Docker.
   package:
     name: "{{ docker_package }}"
     state: "{{ docker_package_state }}"
   notify: restart docker
+
+- name: Prevent docker from being upgraded
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  when: docker_apt_hold|default(false)|bool
+  with_items:
+  - docker-{{ docker_edition }}
+  - docker-{{ docker_edition }}-cli
 
 - name: Ensure Docker is started and enabled at boot.
   service:


### PR DESCRIPTION
Hello,

Thanks for the amazing work.

I would like to make a proposal to add a feature to help people adding a hold on docker package once installed.

Indeed, we have a use cases where we want to hold docker once installed to avoid unwanted upgrades running `apt-get upgrade` for example. Like many people, we want to maintain docker only using this role, and having the possibility to hold the docker package is an interesting feature.

For now, i have not include RedHat solutions for the hold because it seems really complex to hold a package (needs to install a specific plugin). But if someone have a solution i'm glad to edit this PR.
Moreover, i have not move my modifications on the debian file because there is no logic for post-install action. But i can make the necessary work if you want

I'm ready to hear from your feedbacks and make modifications on my PR.

Thank you.
