### PR TITLE
Add ability to configure package mirrors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,17 +16,18 @@ docker_compose_url: https://github.com/docker/compose/releases/download/{{ docke
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
+docker_repo_url: https://download.docker.com/linux
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
-docker_apt_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 
 # Used only for RedHat/CentOS/Fedora.
-docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-{{ docker_edition }}.repo
+docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: https://download.docker.com/linux/centos/gpg
+docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
 
 # A list of users who will be added to the docker group.
 docker_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ docker_restart_handler_state: restarted
 # Docker Compose options.
 docker_install_compose: true
 docker_compose_version: "1.26.0"
+docker_compose_url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check current docker-compose version.
-  command: docker-compose --version
+  command: "{{ docker_compose_path }} --version"
   register: docker_compose_current_version
   changed_when: false
   failed_when: false
@@ -18,3 +18,6 @@
     url: "{{ docker_compose_url }}"
     dest: "{{ docker_compose_path }}"
     mode: 0755
+  when: >
+    docker_compose_current_version.stdout is not defined
+    or docker_compose_version not in docker_compose_current_version.stdout

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -15,6 +15,6 @@
 
 - name: Install Docker Compose (if configured).
   get_url:
-    url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
+    url: "{{ docker_compose_url }}"
     dest: "{{ docker_compose_path }}"
     mode: 0755


### PR DESCRIPTION
These changes are needed for the role to be usable in an offline environment where github.com and docker.com are inaccessible, or if a user desires to use a local mirror. It allows for configuration of the docker-compose download URL, as well as setting a YUM and APT package mirror. Finally, docker-compose is only downloaded when needed.