### PR TITLE
Do not install gnupg2 on Ubuntu 20.04 and superior

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,8 +11,13 @@
     name:
       - apt-transport-https
       - ca-certificates
-      - gnupg2
     state: present
+
+- name: Ensure gnupg2 dependency is installed.
+  apt:
+    name: gnupg2
+    state: present
+  when: ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('20.04', '<')
 
 - name: Add Docker apt key.
   apt_key:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,11 +13,17 @@
       - ca-certificates
     state: present
 
-- name: Ensure gnupg2 dependency is installed.
+- name: Ensure additionnal dependencies are installed (on Ubuntu < 20.04 and any other systems).
   apt:
     name: gnupg2
     state: present
   when: ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('20.04', '<')
+
+- name: Ensure additionnal dependencies are installed (on Ubuntu >= 20.04).
+  apt:
+    name: gnupg
+    state: present
+  when: ansible_distribution == 'Ubuntu' or ansible_distribution_version is version('20.04', '>=')
 
 - name: Add Docker apt key.
   apt_key:


### PR DESCRIPTION
This pull request is about adding a condition to not install `gnupg2` on Ubuntu 20.04 and superior since this package is no more.