### PR TITLE
ignore likely errors if in `ansible_check_mode`

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart docker
   service: "name=docker state={{ docker_restart_handler_state }}"
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
     name: docker
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers


### PR DESCRIPTION
When running playbook using this role for the first time, and in `--check` mode, some things are pretty much guaranteed to fail.  Rather than stop processing, would be nice if we could continue with the rest of the playbook and see what else is likely to change or fail.

I suppose one could be a bit more deliberate about it if you wanted the results/output to be cleaner, but that would require checking if the package is actually installed. 

LMK if you prefer that approach and I'll rework.