### PR TITLE
Explicitly define the package repo filename

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,11 +20,13 @@ docker_repo_url: https://download.docker.com/linux
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repo_filename: "{{ docker_package }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
+docker_yum_repo_filename: "{{ docker_package }}"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
 docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -47,5 +47,6 @@
 - name: Add Docker repository.
   apt_repository:
     repo: "{{ docker_apt_repository }}"
+    filename: "{{ docker_apt_repo_filename }}"
     state: present
     update_cache: true

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -15,14 +15,14 @@
 - name: Add Docker repository.
   get_url:
     url: "{{ docker_yum_repo_url }}"
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+    dest: '/etc/yum.repos.d/{{ docker_yum_repo_filename }}.repo'
     owner: root
     group: root
     mode: 0644
 
 - name: Configure Docker Nightly repo.
   ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+    dest: '/etc/yum.repos.d/{{ docker_yum_repo_filename }}.repo'
     section: 'docker-{{ docker_edition }}-nightly'
     option: enabled
     value: '{{ docker_yum_repo_enable_nightly }}'
@@ -30,7 +30,7 @@
 
 - name: Configure Docker Test repo.
   ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+    dest: '/etc/yum.repos.d/{{ docker_yum_repo_filename }}.repo'
     section: 'docker-{{ docker_edition }}-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'


### PR DESCRIPTION
On debian-flavored systems, failure to do this means that ansible will generate the repository filename (in `/etc/apt/sources.list.d/`), and that filename will include many elements of the repository, which can include distribution name and version numbers.  This means that after upgrading distribution versions, one will end up with multiple repository definitions in separate files rather than updating the same file on each playbook/role execution.

I also updated the naming for RedHat systems, but no behavior change - only the ability to have the user define the filename via variable.

