### PR TITLE
Enable/Disable the (systemd) `docker.service` and `.socket`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,15 @@
     state: "{{ docker_package_state }}"
   notify: restart docker
 
-- name: Ensure Docker is started and enabled at boot.
+- name: Configure docker service and socket state
   service:
-    name: docker
+    name: "docker.{{ item }}"
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  with_items:
+    - service
+    - socket
 
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers


### PR DESCRIPTION
When using this role to install `docker` but only intend for it's use in 
`rootless` mode, the Docker documentation suggests disabling 
`docker.service`.

However, that also leaves the `docker.socket` running, which whenever it 
receieves a connect, the daemon (service) is restarted.  

This patch enables/disables the both the service and the socket.

Resolves #279 