### PR TITLE
moved docker repo url to separate section

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,10 @@ docker_compose_version: "1.26.0"
 docker_compose_url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64
 docker_compose_path: /usr/local/bin/docker-compose
 
-# Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
+# Docker repo url common for linux
 docker_repo_url: https://download.docker.com/linux
+
+# Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"


### PR DESCRIPTION
moved docker repo url to separate section because this url is common for both debian and redhat family.