### PR TITLE
run check task even in check mode

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -2,6 +2,7 @@
 - name: Check current docker-compose version.
   command: "{{ docker_compose_path }} --version"
   register: docker_compose_current_version
+  check_mode: no
   changed_when: false
   failed_when: false
 


### PR DESCRIPTION
When the role is run in check mode, the task "Check current docker-compose version" should not be skipped.