### PR TITLE
Add support for Archlinux.

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -13,6 +13,7 @@
   when: >
     docker_compose_current_version.stdout is defined
     and docker_compose_version not in docker_compose_current_version.stdout
+    and ansible_os_family != "Archlinux"
 
 - name: Install Docker Compose (if configured).
   get_url:
@@ -22,3 +23,12 @@
   when: >
     docker_compose_current_version.stdout is not defined
     or docker_compose_version not in docker_compose_current_version.stdout
+    and ansible_os_family != "Archlinux"
+
+- name: Install Docker Compose (Archlinux)
+  package:
+    name: "docker-compose"
+    state: "{{ docker_package_state }}"
+  notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: ansible_os_family == 'Archlinux'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,15 @@
     state: "{{ docker_package_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
+  when: ansible_os_family != 'Archlinux'
+
+- name: Install Docker (Archlinux).
+  package:
+    name: "docker"
+    state: "{{ docker_package_state }}"
+  notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: ansible_os_family == 'Archlinux'
 
 - name: Ensure /etc/docker/ directory exists.
   file:


### PR DESCRIPTION
It would be nice if this role would support Archlinux. I am currently maintaining my own role for this purpose but I think it would be nice to include this in your role (especially since only minor modifications are necessary).

The Docker package on this platform is called `docker` instead of `docker-ce`, Docker Enterprise is not available for this distribution. Also `docker-compose` is usually installed from the official repositories.
I made some small changes to this role such that it works on Archlinux as well.

I agree this patch might look a bit hacky but seemed to seemed like the least hacky solution compared to everything else I could conceive.

Please let me know what you think or whether I oversaw a trivial way of implementing this. I could understand that you might not be interested in supporting such a niche platform, then I would just continue maintaining my own role or this fork.