### PR TITLE
Add OS specific variable overrides.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Load OS specific package information
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - '{{ansible_distribution}}.yml'
+        - '{{ansible_os_family}}.yml'
+        - default.yml
+      paths:
+        - 'vars'
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Load OS specific package information
+- name: Load OS-specific vars.
   include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
         - default.yml
       paths:
         - 'vars'
+
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,0 +1,2 @@
+---
+docker_package: "docker"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,2 @@
+---
+# Empty file


### PR DESCRIPTION
Specific example is Alpine where the [repos](https://pkgs.alpinelinux.org/packages?name=docker&branch=edge) use `docker` rather than `docker-ce` or `docker-ee`