### PR TITLE
added apt update to debian setup

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -49,3 +49,7 @@
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: true
+    
+- name: Update apt cache
+  apt:
+    update_cache: yes


### PR DESCRIPTION
I had troubles installing docker today.(Ubuntu 20.04). Interestingly, I had no problems on a second machine which actually was identical (both vagrants). I'm not sure how to reproduce tho...

`FAILED! => {"changed": false, "msg": "No package matching 'docker-ce' is available"}`

Went onto the machine and apt cache did not know docker. A small apt update doesn't hurt and would have fixed that.