### PR TITLE
Add docker_service_environment variable to allow environment variables such as HTTP_PROXY.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ You can control whether the package is installed, uninstalled, or at the latest 
     docker_service_state: started
     docker_service_enabled: true
     docker_restart_handler_state: restarted
+    docker_service_environment: {}
 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
+Additional environment variables, such as HTTP_PROXY, HTTPS_PROXY and NO_PROXY can be set with docker_service_environment and will be added to a drop-in systemd directory.
 
     docker_install_compose: true
     docker_compose_version: "1.26.0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ docker_package_state: present
 docker_service_state: started
 docker_service_enabled: true
 docker_restart_handler_state: restarted
+docker_service_environment: {}
 
 # Docker Compose options.
 docker_install_compose: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: systemd daemon-reload
+  systemd:
+    daemon_reload: yes
+
 - name: restart docker
   service: "name=docker state={{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,23 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Ensure systemd drop-in directory exists
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+    mode: 0755
+  when: docker_service_environment.keys() | length > 0
+
+- name: Configure Docker service options.
+  template:
+    src: environment.conf.j2
+    dest: /etc/systemd/system/docker.service.d/environment.conf
+    mode: 0755
+  when: docker_service_environment.keys() | length > 0
+  notify:
+    - systemc daemon-reload
+    - restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     mode: 0755
   when: docker_service_environment.keys() | length > 0
   notify:
-    - systemc daemon-reload
+    - systemd daemon-reload
     - restart docker
 
 - name: Ensure Docker is started and enabled at boot.

--- a/templates/environment.conf.j2
+++ b/templates/environment.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for environment_variable in docker_service_environment.keys() %}
+Environment="{{ environment_variable }}={{ docker_service_environment[environment_variable] }}"
+{% endfor %}


### PR DESCRIPTION
Add a docker_service_environment variable, which allows setting additional environment variables to the systemd service, such as HTTP_PROXY, HTTPS_PROXY and NO_PROXY.