### PR TITLE
refactor: add error check for shell pipe

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -39,6 +39,7 @@
 
 - name: Add Docker apt key (alternative for older systems without SNI).
   shell: >
+    set -e -o pipefail
     curl -sSL {{ docker_apt_gpg_key }} | apt-key add -
   args:
     warn: false


### PR DESCRIPTION
```
risky-shell-pipe: Shells that use pipes should set the pipefail option
tasks/setup-Debian.yml:40 Task/Handler: Add Docker apt key (alternative for older systems without SNI).
```
Fixes geerlingguy/ansible-role-docker#327