### PR TITLE
Support linux mint

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,10 @@ docker_repo_url: https://download.docker.com/linux
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Linux Mint') | ternary('ubuntu', ansible_distribution) | lower }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_apt_repo_url }} {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }} {{ docker_apt_release_channel }}"
+docker_apt_repository: >-
+  deb [arch={{ docker_apt_arch }}] {{ docker_apt_repo_url }} 
+  {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }} 
+  {{ docker_apt_release_channel }}
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_apt_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ docker_apt_repository: >-
    {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }}
    {{ docker_apt_release_channel }}
 docker_apt_ignore_key_error: true
-docker_apt_gpg_key: "{{ docker_apt_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_key: "{{ docker_apt_repo_url }}/gpg"
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,9 +22,10 @@ docker_repo_url: https://download.docker.com/linux
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
 docker_apt_arch: amd64
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Linux Mint') | ternary('ubuntu', ansible_distribution) | lower }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_apt_repo_url }} {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
-docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_key: "{{ docker_apt_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,9 +24,9 @@ docker_apt_release_channel: stable
 docker_apt_arch: amd64
 docker_apt_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Linux Mint') | ternary('ubuntu', ansible_distribution) | lower }}"
 docker_apt_repository: >-
-  deb [arch={{ docker_apt_arch }}] {{ docker_apt_repo_url }} 
-  {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }} 
-  {{ docker_apt_release_channel }}
+  deb [arch={{ docker_apt_arch }}] {{ docker_apt_repo_url }}
+   {{ (ansible_distribution == 'Linux Mint') | ternary(lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release'), ansible_distribution_release) }}
+   {{ docker_apt_release_channel }}
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_apt_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 


### PR DESCRIPTION
I'm not sure whether there is a cleaner way to do this. Anyhow, this works and introduces the least changes.

Basically: Use the appropriate ubuntu repo on linux mint distros.