### PR TITLE
Allow package downgrading

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,22 @@
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Install Docker.
+- name: Install Docker (Ansible <2.12).
   package:
     name: "{{ docker_package }}"
     state: "{{ docker_package_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
+  when: "ansible_version.full is version_compare('2.12', '<')"
+
+- name: Install Docker (Ansible >=2.12).
+  package:
+    name: "{{ docker_package }}"
+    state: "{{ docker_package_state }}"
+    allow_downgrade: true
+  notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: "ansible_version.full is version_compare('2.12', '>=')"
 
 - name: Ensure /etc/docker/ directory exists.
   file:


### PR DESCRIPTION
Dear Jeff,

thanks a stack for this excellent Ansible Role. We submitted this patch at #317 the other day, but it got stale. So, we are taking the opportunity to rebase the patch and submit it again.

The patch will resolve #121 and is based on https://github.com/ansible/ansible/pull/74852. While you shared some concerns with the original implementation at https://github.com/geerlingguy/ansible-role-docker/pull/317#pullrequestreview-815300454, I've improved the implementation since then.

To recap, the conditional dispatching is needed because the `allow_downgrade` option is only available starting with `ansible-core>=2.12` for apt-based systems.

With kind regards,
Andreas.
