### PR TITLE
Allow skipping of service management

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterpri
 
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
+    docker_service_manage: true
     docker_service_state: started
     docker_service_enabled: true
     docker_restart_handler_state: restarted
 
-Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
+Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set `docker_service_manage` to `false`.
 
     docker_install_compose: true
     docker_compose_version: "1.26.0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present
 
 # Service options.
+docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true
 docker_restart_handler_state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: restart docker
   service: "name=docker state={{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  when: docker_service_manage | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  when: docker_service_manage | bool
 
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers


### PR DESCRIPTION
On WSL2 (likely also WSL1) this role fails with this error message:

```
TASK [service] ***********************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Service is in unknown state", "status": {}}
```

This minimal playbook will fail with the same error:

```yaml
---
- hosts: localhost
  tasks:
    - service:
        name: docker
        state: stopped
```

Consequently the `service`  module should not be called by this role in WSL. I added a configuration variable `docker_service_manage` (defaults to `true`) to allow skipping the tasks that call the `service` module.

The README was updated to reflect these changes.