### PR TITLE
Override Systemd conf when hosts is defined

### DIFF
--- a/files/systemd-override.conf
+++ b/files/systemd-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd --containerd=/run/containerd/containerd.sock

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check Systemd configuration
+  command: systemd-analyze verify /lib/systemd/system/docker.service
+  listen: reload systemd
+
 - name: reload systemd
   systemd:
     daemon_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
 - name: restart docker
   service: "name=docker state={{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -22,3 +22,8 @@
 
   roles:
     - role: geerlingguy.docker
+
+  vars:
+    docker_daemon_options:
+      hosts:
+        - unix:///var/run/docker.sock

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,25 @@
     mode: 0755
   when: docker_daemon_options.keys() | length > 0
 
+- name: Override Docker Systemd configuration.
+  block:
+    - name: Create Docker Systemd directory.
+      file:
+        path: /etc/systemd/system/docker.service.d
+        owner: root
+        group: root
+        mode: 0755
+        state: directory
+    - name: Copy Systemd patch.
+      copy:
+        src: systemd-override.conf
+        dest: /etc/systemd/system/docker.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: reload systemd
+  when: "'hosts' in docker_daemon_options.keys()"
+
 - name: Configure Docker daemon options.
   copy:
     content: "{{ docker_daemon_options | to_nice_json }}"
@@ -37,15 +56,15 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Ensure handlers are notified now to avoid firewall conflicts.
+  meta: flush_handlers
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
   ignore_errors: "{{ ansible_check_mode }}"
-
-- name: Ensure handlers are notified now to avoid firewall conflicts.
-  meta: flush_handlers
 
 - include_tasks: docker-compose.yml
   when: docker_install_compose | bool


### PR DESCRIPTION
When ```hosts``` property is defined in ```daemon.json``` it creates a conflict whith default ExecStart from Systemd configuration (```/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock```).

With this PR, when ```hosts``` is defined in var ```docker_daemon_options```, Systemd configuration is patch to not use ```-H``` arg.