### PR TITLE
Fix package downgrading for non-{RedHat,Debian} systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,22 +5,22 @@
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Install Docker (Ansible <2.12).
+- name: Install Docker.
   package:
     name: "{{ docker_package }}"
     state: "{{ docker_package_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '<')"
+  when: "ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian']"
 
-- name: Install Docker (Ansible >=2.12).
+- name: Install Docker (with downgrade option).
   package:
     name: "{{ docker_package }}"
     state: "{{ docker_package_state }}"
     allow_downgrade: true
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '>=')"
+  when: "ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
 
 - name: Ensure /etc/docker/ directory exists.
   file:


### PR DESCRIPTION
Dear @adamantike,

thank you very much for your report at #346:

> Root cause is #336, as the introduced parameter `allow_downgrade` is not supported by the `pacman` manager module, so that using Ansible >= 2.12 on Arch Linux would croak like:
>
>     Unsupported parameters for (ansible.legacy.pacman) module: allow_downgrade.

I feel responsible for that regression, because I just had focussed on Debian and apparently completely missed the big picture. Apologies.

I am submitting this patch to improve the situation as a draft, because I haven't been able to test it hands-on yet. Do you think it would resolve the issue for you? Apparently, as the software tests seem to succeed, can I humbly ask you to give it a try and report back about the outcome?

In order to pull the patched recipe directly from the git repository, you would put something along those lines into your `requirements.yaml` file.
```yaml
roles:
  - name: ansible-role-docker
    src: git+https://github.com/crate-workbench/ansible-role-docker.git
    version: "amo/allow-downgrades-debian-redhat-only"
```

With kind regards,
Andreas.