### PR TITLE
CI: Add Arch Linux to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,10 @@ jobs:
     name: Molecule
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         distro:
+          - archlinux
           - rockylinux8
           - centos7
           - ubuntu2004
@@ -64,9 +66,24 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ansible molecule[docker] docker
 
+      - name: Provide MOLECULE_DISTRO to environment
+        run: echo "MOLECULE_DISTRO=${{ matrix.distro || 'centos7' }}" >> $GITHUB_ENV
+
       - name: Run Molecule tests.
+        if: matrix.distro != 'archlinux'
         run: molecule test
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_DISTRO: ${{ matrix.distro }}
+          CI_IMAGE: geerlingguy/docker-${{ env.MOLECULE_DISTRO }}-ansible:latest
+
+      - name: Run Molecule tests on Arch Linux.
+        if: matrix.distro == 'archlinux'
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          # CI_IMAGE: mesaguy/ansible-molecule-archlinux:latest
+          # CI_IMAGE: carlodepieri/docker-archlinux-ansible:latest
+          # CI_IMAGE: ghcr.io/avnes/molecule-arch:latest
+          CI_IMAGE: archlinux:base-20210328.0.18194

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,10 +5,13 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    image: ${CI_IMAGE}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
 provisioner:


### PR DESCRIPTION
Hi again,

#336 introduced a regression because a parameter has been added which is only present for Red Hat and Debian systems, but croaks, for example, on Arch Linux. Thanks for reporting it through #346, @adamantike.

When adding other Linux distributions to the test suite, errors like this might get caught early. If this patch turns out to work sucessfully and is welcome in general, #352 should be based upon it.

With kind regards,
Andreas.

P.S.: This patch has been inspired by suggestions from others. Kudos!
- https://github.com/ansible-community/molecule/discussions/3410
- [How to perform string manipulation while declaring env vars in GitHub Actions](https://stackoverflow.com/a/60445893)
- [Error When Testing Archlinux with Ansible Molecule](https://stackoverflow.com/questions/67172650/error-when-testing-archlinux-with-ansible-molecule)
