### PR TITLE
fix: remove extra spaces on enable option in ini files

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,6 +27,7 @@
     option: enabled
     value: '{{ docker_yum_repo_enable_nightly }}'
     mode: 0644
+    no_extra_spaces: yes
 
 - name: Configure Docker Test repo.
   ini_file:
@@ -35,6 +36,7 @@
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
     mode: 0644
+    no_extra_spaces: yes
 
 - name: Configure containerd on RHEL 8.
   block:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,7 +27,7 @@
     option: enabled
     value: '{{ docker_yum_repo_enable_nightly }}'
     mode: 0644
-    no_extra_spaces: yes
+    no_extra_spaces: true
 
 - name: Configure Docker Test repo.
   ini_file:
@@ -36,7 +36,7 @@
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
     mode: 0644
-    no_extra_spaces: yes
+    no_extra_spaces: true
 
 - name: Configure containerd on RHEL 8.
   block:


### PR DESCRIPTION
The repo file provided from docker has no spaces before and after the `=` in the ini file. The Ansible task `ini_file` adds spaces before and after the `=` and therefore, even though no change is required since the value is the same, the file is still touch and a change is reported by Ansible.

This fix adds the option `no_extra_spaces: true` option to the two `ini_file` tasks in the RedHat setup tasks.