### PR TITLE
Correct gnupg installation condition

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -23,7 +23,7 @@
   apt:
     name: gnupg
     state: present
-  when: ansible_distribution == 'Ubuntu' or ansible_distribution_version is version('20.04', '>=')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')
 
 - name: Add Docker apt key.
   apt_key:


### PR DESCRIPTION
The condition for whether to install gnupg (vs. gnupg2) is incorrect; it should be an inverse of the gnupg2 one but instead checks for a Ubuntu version on non-Ubuntu (i.e. Debian) distributions. 