### PR TITLE
Avoid string-based module configuration

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart docker
-  service: "name=docker state={{ docker_restart_handler_state }}"
+  service:
+    name: docker
+    state: "{{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
Configure module parameters as a YAML dict instead of string.

This PR falls right into the bikeshedding category, but I just had a discussion with a friend about this. We kind of believe that the syntax of configuring a module by a single string is kind of deprecated, at least we thought that we heard it somewhere. I am sadly not able to find a reference for this. But I noticed this is the only place where this is the case.

Personally, while I like compact ways of writing things, I also understand that it is confusing for Ansible beginners to have '=' and ':' mixed… since there is also no strict rules for quoting, they might not realize the 'one is a string, the other a dict' difference. This can be avoided by avoiding the string form.

(PS: Also, it would be kind of nice if the string-form with `:` were to be deprecated and forbidden, while allowing a string-form that mimics YAML by using `=`, which would be less confusing. Also the modules could have one parameter marked as 'primary' that may be specified in string form without setting the key, as long as it is the only parameter. Then `timezone: "name: Asia/Tokyo"` would become `timezone: "Asia/Tokyo"`. This is a pattern for for example in Java annotations (with their 'value' parameter)… but that would break a lot of things, I guess. Well different topic… xD)