### PR TITLE
Make service management entirely optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterpri
 
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
+    docker_service_managed: true
     docker_service_state: started
     docker_service_enabled: true
     docker_restart_handler_state: restarted
 
-Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
+Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a distribution without an init system (e.g. inside a Docker container, WSL), set `docker_service_managed` to `false`. 
 
     docker_install_compose: true
     docker_compose_version: "1.26.0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ docker_package: "docker-{{ docker_edition }}"
 docker_package_state: present
 
 # Service options.
+docker_service_managed: true
 docker_service_state: started
 docker_service_enabled: true
 docker_restart_handler_state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
     name: docker
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
+  when: docker_service_managed | bool
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure handlers are notified now to avoid firewall conflicts.


### PR DESCRIPTION
The provided advice of circumventing service management
did not work for me, usage still failed in WSL:

```
TASK [geerlingguy.docker : Ensure Docker is started and enabled at boot.] **********************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Service is in unknown state", "status": {}}
```

Thus, this adds the option `docker_service_managed`
that allows skipping any service management completely.