### PR TITLE
Add installation of docker plugin from docker's repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ You can control whether the package is installed, uninstalled, or at the latest 
 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set these to `stopped` and set the enabled variable to `no`.
 
+    docker_install_compose_plugin: false
+    docker_compose_package: docker-compose-plugin
+    docker_compose_package_state: present
+
+Docker Compose Plugin installation options. These differ from the below in that docker-compose is installed as a docker plugin (and used with `docker compose`) instead of a standalone binary.
+
     docker_install_compose: true
     docker_compose_version: "1.26.0"
     docker_compose_arch: x86_64

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,11 @@ docker_service_state: started
 docker_service_enabled: true
 docker_restart_handler_state: restarted
 
+# Docker Compose Plugin options.
+docker_install_compose_plugin: false
+docker_compose_package: docker-compose-plugin
+docker_compose_package_state: present
+
 # Docker Compose options.
 docker_install_compose: true
 docker_compose_version: "v2.4.1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,23 @@
   ignore_errors: "{{ ansible_check_mode }}"
   when: "ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
 
+- name: Install docker-compose plugin.
+  package:
+    name: "{{ docker_compose_package }}"
+    state: "{{ docker_compose_package_state }}"
+  notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: "docker_install_compose_plugin | bool == true and (ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian'])"
+
+- name: Install docker-compose-plugin (with downgrade option).
+  package:
+    name: "{{ docker_compose_package }}"
+    state: "{{ docker_compose_package_state }}"
+    allow_downgrade: true
+  notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: "docker_install_compose_plugin | bool == true and ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
+
 - name: Ensure /etc/docker/ directory exists.
   file:
     path: /etc/docker


### PR DESCRIPTION
Fixes #355.

Copied the strategy of the package install for the docker daemon. I left the compose binary enabled as the default, and the compose plugin disabled to avoid breaking any old installs/configs. At some point, though, that should probably be flipped as only the plugin will be supported moving forward.

@geerlingguy please let me know if you'd like any changes.