### PR TITLE
#205 - install Docker packages explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
         distro:
           - rockylinux8
           - centos7
+          - ubuntu2204
           - ubuntu2004
           - ubuntu1804
           - debian11
           - debian10
-          - debian9
           - fedora34
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ Available variables are listed below, along with default values (see `defaults/m
 
     # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
     docker_edition: 'ce'
-    docker_package: "docker-{{ docker_edition }}"
-    docker_package_state: present
+    docker_packages:
+        - "docker-{{ docker_edition }}"
+        - "docker-{{ docker_edition }}-cli"
+        - "docker-{{ docker_edition }}-rootless-extras"
+    docker_packages_state: present
 
-The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). You can also specify a specific version of Docker to install using the distribution-specific format: Red Hat/CentOS: `docker-{{ docker_edition }}-<VERSION>`; Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>`.
+The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). 
+You can also specify a specific version of Docker to install using the distribution-specific format: 
+Red Hat/CentOS: `docker-{{ docker_edition }}-<VERSION>` (Note: you have to add this to all packages);
+Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>` (Note: you have to add this to all packages).
 
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,12 @@
 ---
 # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
 docker_edition: 'ce'
-docker_package: "docker-{{ docker_edition }}"
-docker_package_state: present
+docker_packages:
+  - "docker-{{ docker_edition }}"
+  - "docker-{{ docker_edition }}-cli"
+  - "docker-{{ docker_edition }}-rootless-extras"
+  - "containerd.io"
+docker_packages_state: present
 
 # Service options.
 docker_service_state: started

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,14 +18,13 @@ galaxy_info:
         - all
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
+        - jammy
   galaxy_tags:
     - web
     - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,18 +5,18 @@
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Install Docker.
+- name: Install Docker packages.
   package:
-    name: "{{ docker_package }}"
-    state: "{{ docker_package_state }}"
+    name: "{{ docker_packages }}"
+    state: "{{ docker_packages_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
   when: "ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian']"
 
-- name: Install Docker (with downgrade option).
+- name: Install Docker packages (with downgrade option).
   package:
-    name: "{{ docker_package }}"
-    state: "{{ docker_package_state }}"
+    name: "{{ docker_packages }}"
+    state: "{{ docker_packages_state }}"
     allow_downgrade: true
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
Fixes #205.

As [requested here](https://github.com/geerlingguy/ansible-role-docker/issues/205#issuecomment-1068121131) explicitly install all Docker packages and changes the variable(s) name(s).

One note/suggestion: 

You requested to change the name of the variable(s) which makes this a breaking change for the users which configure/override this variable(s). May I ask why? Is it just to be more clear and for naming conventions? Because there is no real need for this. The `package` module supports both strings and lists. 

Keeping it the old way but with a slightly wrong name it would not be a breaking change.