### PR TITLE
reset ssh connection to allow user changes to affect current login user

### DIFF
--- a/tasks/docker-users.yml
+++ b/tasks/docker-users.yml
@@ -5,3 +5,7 @@
     groups: docker
     append: true
   with_items: "{{ docker_users }}"
+
+- name: Reset ssh connection to apply users changes
+  meta:
+    reset_connection

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,5 +79,20 @@
 - include_tasks: docker-compose.yml
   when: docker_install_compose | bool
 
-- include_tasks: docker-users.yml
+- name: Get all docker group infos
+  getent:
+    database: group
+    key: docker
+    split: ':'
   when: docker_users | length > 0
+
+- name: Check there is at least one user to add to docker group
+  set_fact:
+    at_least_one_user_to_modify: true
+  when:
+    - docker_users | length > 0
+    - item not in ansible_facts.getent_group["docker"][2]
+  with_items: "{{ docker_users }}"
+
+- include_tasks: docker-users.yml
+  when: at_least_one_user_to_modify is defined


### PR DESCRIPTION
### Linked issues:
* https://github.com/geerlingguy/ansible-role-docker/issues/237
* https://github.com/geerlingguy/ansible-role-docker/issues/308

### Why:
Without this modification, we can't use docker in same playbook than the one which install docker (in the case of we use `docker_users` variable).

### How:
Check that `docker_users` are set and not in docker group before include `docker-users.yml`. In `docker-users.yml` we call reset_connection` from [ansible.builtin.meta](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/meta_module.html) collection after `docker_users` are added to docker group.

### Manual success tests:
* Try to install docker with only one user in docker-users and not in docker group => docker-users.yml include
* Try to install docker with only one user in docker-users but the user is in docker group => docker-users.yml not include
* Try to install docker with 2 users in docker-users, one user in docker group and the second not => docker-users.yml include
* Try to install docker with 2 users in docker-users, both are in docker group => docker-users.yml not include
* Try to install docker with 2 users in docker-users, both are not in docker group => docker-users.yml include