### PR TITLE
Feature : Replace the official docker repo by a remote repo.

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -26,8 +26,8 @@
     regexp: '{{ __current_item }}'
     replace: '{{ docker_repo_url }}'
   with_items:
-  - 'https://download.docker.com/linux'
-  - 'https://download-stage.docker.com/linux/'
+    - 'https://download.docker.com/linux'
+    - 'https://download-stage.docker.com/linux/'
   loop_control:
     loop_var: "__current_item"
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -20,6 +20,12 @@
     group: root
     mode: 0644
 
+- name: Replace Docker default domain repo.
+  ansible.builtin.replace:
+    path: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+    regexp: 'https://download.docker.com/linux'
+    replace: '{{ docker_repo_url }}'
+
 - name: Configure Docker Nightly repo.
   ini_file:
     dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -23,8 +23,13 @@
 - name: Replace Docker default domain repo.
   ansible.builtin.replace:
     path: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    regexp: 'https://download.docker.com/linux'
+    regexp: '{{ __current_item }}'
     replace: '{{ docker_repo_url }}'
+  with_items:
+  - 'https://download.docker.com/linux'
+  - 'https://download-stage.docker.com/linux/'
+  loop_control:
+    loop_var: "__current_item"
 
 - name: Configure Docker Nightly repo.
   ini_file:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,7 +27,7 @@
     replace: '{{ docker_repo_url }}'
   with_items:
     - 'https://download.docker.com/linux'
-    - 'https://download-stage.docker.com/linux/'
+    - 'https://download-stage.docker.com/linux'
   loop_control:
     loop_var: "__current_item"
 


### PR DESCRIPTION
Hi 
Thanks for your work. I'm actually using your role to configure a server without rewriting the official guideline but with a little modification. :) 

## Why this MR ? 
I'm working under private network and using artefacts managers Software to got mirrors (Ex: Nexus, Artifactory). 

So i have to modify the role to got natively  docker-ce.repo configured as i want.  I dont want to setup a repo file with custom configuration. I wont to archive the file... I suggest, it's to put this remote depo change , transparent to user.

So if you are interested by the MR. It will be a pleasure to share this simple modification for RedHat distributions. It's may open the subject to others distributions.

## How it was used/ tested?
_Exemple:_ 
```
roles: 
  - role: ansible-roler-docker
vars : 
  docker_repo_url: https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux
  docker_yum_repo_url: "{{ docker_repo_url  }}/centos/docker-{{ docker_edition }}.repo"
  docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
```

**Before MR :**
`head -27 /etc/yum.repos.d/docker-ce.repo`
> [docker-ce-stable]
name=Docker CE Stable - $basearch
baseurl=https://download.docker.com/linux/centos/$releasever/$basearch/stable
enabled=1
gpgcheck=1
gpgkey=https://download.docker.com/linux/centos/gpg
>
> [docker-ce-stable-debuginfo]
name=Docker CE Stable - Debuginfo $basearch
baseurl=https://download.docker.com/linux/centos/$releasever/debug-$basearch/stable
enabled=0
gpgcheck=1
gpgkey=https://download.docker.com/linux/centos/gpg
>
> [docker-ce-stable-source]
name=Docker CE Stable - Sources
baseurl=https://download.docker.com/linux/centos/$releasever/source/stable
enabled=0
gpgcheck=1
gpgkey=https://download.docker.com/linux/centos/gpg
>
> [docker-ce-test]
name=Docker CE Test - $basearch
baseurl=https://download.docker.com/linux/centos/$releasever/$basearch/test
enabled=0
gpgcheck=1
gpgkey=https://download.docker.com/linux/centos/gpg

**After MR :**
 `head -27 /etc/yum.repos.d/docker-ce.repo`
>[docker-ce-stable]
name=Docker CE Stable - $basearch
baseurl=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/$releasever/$basearch/stable
enabled=1
gpgcheck=1
gpgkey=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/gpg
>
> [docker-ce-stable-debuginfo]
name=Docker CE Stable - Debuginfo $basearch
baseurl=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/$releasever/debug-$basearch/stable
enabled=0
gpgcheck=1
gpgkey=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/gpg
>
> [docker-ce-stable-source]
name=Docker CE Stable - Sources
baseurl=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/$releasever/source/stable
enabled=0
gpgcheck=1
gpgkey=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/gpg
>
> [docker-ce-test]
name=Docker CE Test - $basearch
baseurl=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/$releasever/$basearch/test
enabled=0
gpgcheck=1
gpgkey=https://artefacts.enterprise.com/remote-rpm-download.docker.com/linux/centos/gpg



Have a nice day :)