### PR TITLE
Fixes #290: Allow role to work on ARM64 out of the box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Docker Compose Plugin installation options. These differ from the below in that 
 
     docker_install_compose: true
     docker_compose_version: "1.26.0"
-    docker_compose_arch: x86_64
+    docker_compose_arch: "{{ ansible_architecture }}"
     docker_compose_path: /usr/local/bin/docker-compose
 
 Docker Compose installation options.
@@ -52,7 +52,7 @@ Docker Compose installation options.
 The main Docker repo URL, common between Debian and RHEL systems.
 
     docker_apt_release_channel: stable
-    docker_apt_arch: amd64
+    docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
     docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     docker_apt_ignore_key_error: True
     docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,8 @@ docker_compose_package_state: present
 
 # Docker Compose options.
 docker_install_compose: true
-docker_compose_version: "v2.4.1"
-docker_compose_arch: x86_64
+docker_compose_version: "v2.11.1"
+docker_compose_arch: "{{ ansible_architecture }}"
 docker_compose_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-linux-{{ docker_compose_arch }}"
 docker_compose_path: /usr/local/bin/docker-compose
 
@@ -31,7 +31,7 @@ docker_repo_url: https://download.docker.com/linux
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
-docker_apt_arch: amd64
+docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"


### PR DESCRIPTION
See #290. Basically make it so the role will work on x86_64 and arm64 out of the box, with no changes required. Can still override the arch for other unique situations.