### PR TITLE
Set default docker_package for Archlinux distribution

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,7 @@ galaxy_info:
     - name: Alpine
       version:
         - all
-    - name: Arch
+    - name: ArchLinux
       versions:
         - all
   galaxy_tags:

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,2 @@
+---
+docker_package: "docker"


### PR DESCRIPTION
Instead of the current role's default value for `docker_package` (`docker-ce`), the package name for the Archlinux OS distribution is `docker` [1].

Considerations:
* Filename is `Archlinux`, as that is the possible value exposed by Ansible, in `ansible_distribution` [2] and `ansible_os_family` [3].
* Platform name in meta's `galaxy_info` has been changed to `ArchLinux`, as that's the supported platform name in Ansible Galaxy [4].

[1] https://archlinux.org/packages/community/x86_64/docker/
[2] https://docs.ansible.com/ansible/2.6/user_guide/playbooks_conditionals.html#ansible-distribution
[3] https://docs.ansible.com/ansible/2.6/user_guide/playbooks_conditionals.html#ansible-os-family
[4] https://galaxy.ansible.com/api/v1/platforms/?name__icontains=arch