### PR TITLE
Upgrade the OpenPGP key retrieval

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,10 +31,11 @@ docker_repo_url: https://download.docker.com/linux
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
-docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
-docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_keyring: "/usr/share/keyrings/docker-archive-keyring.gpg"
+docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by={{docker_apt_gpg_keyring}}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_ignore_key_error: true
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -28,7 +28,7 @@
 - name: Add Docker apt key.
   ansible.builtin.get_url:
     url: "{{ docker_apt_gpg_key }}"
-    dest: /etc/apt/trusted.gpg.d/docker.asc
+    dest: "{{ docker_apt_gpg_keyring }}_armored"
     mode: '0644'
     force: true
   register: add_repository_key
@@ -44,6 +44,17 @@
   args:
     warn: false
   when: add_repository_key is failed
+
+- name: De-Armor Docker signing key
+  command: gpg --yes --dearmor -o "{{ docker_apt_gpg_keyring }}" "{{ docker_apt_gpg_keyring }}_armored"
+  no_log: true
+  args:
+    creates: "{{ docker_apt_gpg_keyring }}"
+
+- name: Set permission to the docker Signing key
+  file:
+    path: "{{ docker_apt_gpg_keyring }}"
+    mode: '0644'
 
 - name: Add Docker repository.
   apt_repository:


### PR DESCRIPTION
As the apt-key method has been deprecated, this commit includes the recommended `signed-by` directive in the repository definition.

Followed the tips here:
https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html