### PR TITLE
Remove docker-ee support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    docker_packages:
-        - "docker-ce"
-        - "docker-ce-cli"
-        - "docker-ce-rootless-extras"
-    docker_packages_state: present
-
-You can also specify a specific version of Docker to install using the distribution-specific format:
+You can specify a specific version of Docker to install using the distribution-specific format:
 Red Hat/CentOS: `docker-ce-<VERSION>` (Note: you have to add this to all packages);
 Debian/Ubuntu: `docker-ce=<VERSION>` (Note: you have to add this to all packages).
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,15 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    # Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
-    docker_edition: 'ce'
     docker_packages:
-        - "docker-{{ docker_edition }}"
-        - "docker-{{ docker_edition }}-cli"
-        - "docker-{{ docker_edition }}-rootless-extras"
+        - "docker-ce"
+        - "docker-ce-cli"
+        - "docker-ce-rootless-extras"
     docker_packages_state: present
 
-The `docker_edition` should be either `ce` (Community Edition) or `ee` (Enterprise Edition). 
-You can also specify a specific version of Docker to install using the distribution-specific format: 
-Red Hat/CentOS: `docker-{{ docker_edition }}-<VERSION>` (Note: you have to add this to all packages);
-Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>` (Note: you have to add this to all packages).
+You can also specify a specific version of Docker to install using the distribution-specific format:
+Red Hat/CentOS: `docker-ce-<VERSION>` (Note: you have to add this to all packages);
+Debian/Ubuntu: `docker-ce=<VERSION>` (Note: you have to add this to all packages).
 
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_package_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
@@ -62,7 +59,7 @@ The main Docker repo URL, common between Debian and RHEL systems.
 You can change `docker_apt_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror.
 Usually in combination with changing `docker_apt_repository` as well.
 
-    docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"docker_edition }}.repo
+    docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-ce.repo"
     docker_yum_repo_enable_nightly: '0'
     docker_yum_repo_enable_test: '0'
     docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
@@ -119,7 +116,7 @@ MIT / BSD
 
 ## Sponsors
 
-* [We Manage](https://we-manage.de): Helping start-ups and grown-ups scaling their infrastructure in a sustainable way.
+- [We Manage](https://we-manage.de): Helping start-ups and grown-ups scaling their infrastructure in a sustainable way.
 
 The above sponsor(s) are supporting Jeff Geerling on [GitHub Sponsors](https://github.com/sponsors/geerlingguy). You can sponsor Jeff's work too, to help him continue improving these Ansible open source projects!
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ MIT / BSD
 
 ## Sponsors
 
-- [We Manage](https://we-manage.de): Helping start-ups and grown-ups scaling their infrastructure in a sustainable way.
+* [We Manage](https://we-manage.de): Helping start-ups and grown-ups scaling their infrastructure in a sustainable way.
 
 The above sponsor(s) are supporting Jeff Geerling on [GitHub Sponsors](https://github.com/sponsors/geerlingguy). You can sponsor Jeff's work too, to help him continue improving these Ansible open source projects!
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+    docker_packages:
+        - "docker-ce"
+        - "docker-ce-cli"
+        - "docker-ce-rootless-extras"
+    docker_packages_state: present
+
 You can specify a specific version of Docker to install using the distribution-specific format:
 Red Hat/CentOS: `docker-ce-<VERSION>` (Note: you have to add this to all packages);
 Debian/Ubuntu: `docker-ce=<VERSION>` (Note: you have to add this to all packages).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,8 @@
 ---
-# Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
-docker_edition: 'ce'
 docker_packages:
-  - "docker-{{ docker_edition }}"
-  - "docker-{{ docker_edition }}-cli"
-  - "docker-{{ docker_edition }}-rootless-extras"
+  - "docker-ce"
+  - "docker-ce-cli"
+  - "docker-ce-rootless-extras"
   - "containerd.io"
 docker_packages_state: present
 
@@ -37,7 +35,7 @@ docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
 
 # Used only for RedHat/CentOS/Fedora.
-docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
+docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-ce.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
 docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -15,15 +15,15 @@
 - name: Add Docker repository.
   get_url:
     url: "{{ docker_yum_repo_url }}"
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
+    dest: '/etc/yum.repos.d/docker-ce.repo'
     owner: root
     group: root
     mode: 0644
 
 - name: Configure Docker Nightly repo.
   ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    section: 'docker-{{ docker_edition }}-nightly'
+    dest: '/etc/yum.repos.d/docker-ce.repo'
+    section: 'docker-ce-nightly'
     option: enabled
     value: '{{ docker_yum_repo_enable_nightly }}'
     mode: 0644
@@ -31,8 +31,8 @@
 
 - name: Configure Docker Test repo.
   ini_file:
-    dest: '/etc/yum.repos.d/docker-{{ docker_edition }}.repo'
-    section: 'docker-{{ docker_edition }}-test'
+    dest: '/etc/yum.repos.d/docker-ce.repo'
+    section: 'docker-ce-test'
     option: enabled
     value: '{{ docker_yum_repo_enable_test }}'
     mode: 0644


### PR DESCRIPTION
Mirantis has removed docker-ee (now known as Mirantis Container Runtime) from the normal repos, it is available from https://repos.mirantis.com/, but only docker-ee.

Additionally, the docker compose plugin is not available at all in the Mirantis repo, which complicates moving to basing things on the plugin instead of the separate golang binary from GitHub.

Finally, many architectures are missing from docker-ee, and sources are not available universally.

It would be better for maintainability for this project to drop the already broken docker-ee instead of making all of conditionals to handle the self-inflicted edge cases created by Mirantis.

Resolves #387 