### PR TITLE
Support armhf

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Docker Compose installation options.
 The main Docker repo URL, common between Debian and RHEL systems.
 
     docker_apt_release_channel: stable
-    docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+    docker_apt_arch: "{{ {'x86_64': 'amd64', 'armv7l': 'armhf', 'aarch64': 'arm64'}[ansible_architecture] }}"
     docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     docker_apt_ignore_key_error: True
     docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ docker_repo_url: https://download.docker.com/linux
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
-docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+docker_apt_arch: "{{ {'x86_64': 'amd64', 'armv7l': 'armhf', 'aarch64': 'arm64'}[ansible_architecture] }}"
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"


### PR DESCRIPTION
In #376 , only arm64 is supported. This PR should make it work on armhf out-of-box.