### PR TITLE
Add flag to deactivate repository configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Docker Compose Plugin installation options. These differ from the below in that 
 
 Docker Compose installation options.
 
+    docker_add_repo: true
+
+Controls whether this role will add the official Docker repository. Set to `false` if you want to use the default docker packages for your system or manage the package repository on your own.
+
     docker_repo_url: https://download.docker.com/linux
 
 The main Docker repo URL, common between Debian and RHEL systems.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ docker_compose_arch: "{{ ansible_architecture }}"
 docker_compose_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-linux-{{ docker_compose_arch }}"
 docker_compose_path: /usr/local/bin/docker-compose
 
+# Enable repo setup
+docker_add_repo: true
+
 # Docker repo URL.
 docker_repo_url: https://download.docker.com/linux
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -33,18 +33,20 @@
     force: true
   register: add_repository_key
   ignore_errors: "{{ docker_apt_ignore_key_error }}"
+  when: docker_add_repo | bool
 
 - name: Ensure curl is present (on older systems without SNI).
   package: name=curl state=present
-  when: add_repository_key is failed
+  when: add_repository_key is failed and docker_add_repo | bool
 
 - name: Add Docker apt key (alternative for older systems without SNI).
   shell: >
     curl -sSL {{ docker_apt_gpg_key }} | apt-key add -
-  when: add_repository_key is failed
+  when: add_repository_key is failed and docker_add_repo | bool
 
 - name: Add Docker repository.
   apt_repository:
     repo: "{{ docker_apt_repository }}"
     state: present
     update_cache: true
+  when: docker_add_repo | bool

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,6 +12,7 @@
       - apt-transport-https
       - ca-certificates
     state: present
+  when: docker_add_repo | bool
 
 - name: Ensure additional dependencies are installed (on Ubuntu < 20.04 and any other systems).
   apt:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -11,6 +11,7 @@
   rpm_key:
     key: "{{ docker_yum_gpg_key }}"
     state: present
+  when: docker_add_repo | bool
 
 - name: Add Docker repository.
   get_url:
@@ -19,6 +20,7 @@
     owner: root
     group: root
     mode: 0644
+  when: docker_add_repo | bool
 
 - name: Configure Docker Nightly repo.
   ini_file:
@@ -28,6 +30,7 @@
     value: '{{ docker_yum_repo_enable_nightly }}'
     mode: 0644
     no_extra_spaces: true
+  when: docker_add_repo | bool
 
 - name: Configure Docker Test repo.
   ini_file:
@@ -37,6 +40,7 @@
     value: '{{ docker_yum_repo_enable_test }}'
     mode: 0644
     no_extra_spaces: true
+  when: docker_add_repo | bool
 
 - name: Configure containerd on RHEL 8.
   block:


### PR DESCRIPTION
When using on environments with already pre-configured repositories it is useful to be able to skip tasks configuring a specific docker repository