### PR TITLE
Add a variable to prevent auto-start on package installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ docker_packages:
 docker_packages_state: present
 
 # Service options.
+docker_service_prevent_autostart: false
 docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,15 @@
     state: "{{ docker_packages_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian']"
+  when: "(not (docker_service_prevent_autostart | bool)) and (ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian'])"
+
+- name: Install Docker packages (and prevent auto-start).
+  package:
+    name: "{{ docker_packages }}"
+    state: "{{ docker_packages_state }}"
+    policy_rc_d: 101
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: "ansible_os_family == 'Debian' and docker_service_prevent_autostart | bool and ansible_version.full is version_compare('2.12', '<')"
 
 - name: Install Docker packages (with downgrade option).
   package:
@@ -31,7 +39,16 @@
     allow_downgrade: true
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
+  when: "(not (docker_service_prevent_autostart | bool)) and (ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian'])"
+
+- name: Install Docker packages (with downgrade option) (and prevent auto-start).
+  package:
+    name: "{{ docker_packages }}"
+    state: "{{ docker_packages_state }}"
+    allow_downgrade: true
+    policy_rc_d: 101
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: "ansible_os_family == 'Debian' and docker_service_prevent_autostart | bool and ansible_version.full is version_compare('2.12', '>=')"
 
 - name: Install docker-compose plugin.
   package:


### PR DESCRIPTION
At the time of committing :
* No RPM packages for CentOS has an action that start the service in post-installation scripts
* All DPKG packages for Debian, Rasbian and Ubuntu have an action that start the service in post-installation scripts

This commit adds the `docker_service_prevent_autostart` variable. When set to `true`, prevents service start on package installation.