### PR TITLE
Rootless docker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ docker_packages:
   - "docker-{{ docker_edition }}-rootless-extras"
   - "containerd.io"
 docker_packages_state: present
+docker_rootless: false
 
 # Service options.
 docker_service_manage: true

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -26,12 +26,13 @@
 - name: Install rootless docker
   become: false
   command: /usr/bin/dockerd-rootless-setuptool.sh install
+  when: rootless_conf.stat.exists == false
 
 - name: Enable and start rootless docker
   become: false
   systemd:
-    name: docker
-    state: started
+    name: docker.service
+    state: restarted
     enabled: true
     scope: user
 

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -1,0 +1,45 @@
+---
+- name: Ensure dockerd-rootless-setup.sh is installed
+  apt:
+    name:
+      - uidmap
+      - docker-ce-rootless-extras
+    state: present
+
+- name: Stop any running root instances of docker daemon
+  systemd:
+    name: docker.service
+    state: stopped
+    enabled: false
+
+- name: Close root docker socket
+  systemd:
+    name: docker.socket
+    state: stopped
+    enabled: false
+
+- name: Remove docker.sock file
+  file:
+    path: /var/run/docker.sock
+    state: absent
+
+- name: Install rootless docker
+  become: false
+  command: /usr/bin/dockerd-rootless-setuptool.sh install
+
+- name: Enable and start rootless docker
+  become: false
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
+    scope: user
+
+- name: Decouple rootless docker from user session
+  command: loginctl enable-linger {{ ansible_user }}
+
+- name: Add DOCKER_HOST to systemwide environment file
+  lineinfile:
+    path: /etc/environment
+    insertafter: EOF
+    line: 'DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock'

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -36,10 +36,10 @@
     scope: user
 
 - name: Decouple rootless docker from user session
-  command: loginctl enable-linger {{ ansible_user }}
+  command: "loginctl enable-linger {{ ansible_user }}"
 
 - name: Add DOCKER_HOST to systemwide environment file
   lineinfile:
     path: /etc/environment
     insertafter: EOF
-    line: 'DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock'
+    line: "DOCKER_HOST=unix://{{ lookup('env', 'XDG_RUNTIME_DIR') }}/docker.sock"

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -32,7 +32,7 @@
   systemd:
     name: docker
     state: started
-    enabled: yes
+    enabled: true
     scope: user
 
 - name: Decouple rootless docker from user session

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -1,10 +1,19 @@
 ---
 - name: Ensure dockerd-rootless-setup.sh is installed
-  apt:
+  package:
     name:
       - uidmap
       - docker-ce-rootless-extras
     state: present
+  when: ansible_distribution != "CentOS"
+
+- name: Ensure dockerd-rootless-setup.sh is installed
+  package:
+    name:
+      - shadow-utils
+      - docker-ce-rootless-extras
+    state: present
+  when: ansible_distribution == "CentOS"
 
 - name: Stop any running root instances of docker daemon
   service:
@@ -22,6 +31,10 @@
   file:
     path: /var/run/docker.sock
     state: absent
+
+- name: Modprobe ip_tables
+  modprobe:
+    name: ip_tables
 
 - name: Install rootless docker
   become: false

--- a/tasks/docker-rootless.yml
+++ b/tasks/docker-rootless.yml
@@ -7,13 +7,13 @@
     state: present
 
 - name: Stop any running root instances of docker daemon
-  systemd:
+  service:
     name: docker.service
     state: stopped
     enabled: false
 
 - name: Close root docker socket
-  systemd:
+  service:
     name: docker.socket
     state: stopped
     enabled: false
@@ -32,9 +32,10 @@
   become: false
   systemd:
     name: docker.service
-    state: restarted
-    enabled: true
+    state: "{{ docker_service_state }}"
+    enabled: "{{ docker_service_enabled }}"
     scope: user
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Decouple rootless docker from user session
   command: "loginctl enable-linger {{ ansible_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,11 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Uninstall rootless docker
+  become: false
+  command: /usr/bin/dockerd-rootless-setuptool.sh uninstall --force
+  when: docker_rootless == false
+
 - name: Ensure Docker is started and enabled at boot
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,13 +65,17 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
-- name: Ensure Docker is started and enabled at boot.
+- name: Ensure Docker is started and enabled at boot
   service:
     name: docker
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
   ignore_errors: "{{ ansible_check_mode }}"
-  when: docker_service_manage | bool
+  when: docker_service_manage | bool and docker_rootless == false
+
+- name: Setting up docker daemon as non-root
+  include_tasks: docker-rootless.yml
+  when: docker_rootless == true
 
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,6 +75,13 @@
   command: /usr/bin/dockerd-rootless-setuptool.sh uninstall --force
   when: docker_rootless == false and rootless_conf.stat.exists
 
+- name: Reset DOCKER_HOST environment
+  lineinfile:
+    path: /etc/environment
+    state: absent
+    regexp: '^DOCKER_HOST=unix:///run/user/.*/docker.sock$'
+  when: docker_rootless == false and rootless_conf.stat.exists
+
 - name: Ensure Docker is started and enabled at boot
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,10 +65,15 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Stat for rootless docker
+  stat:
+    path: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/docker.sock"
+  register: rootless_conf
+
 - name: Uninstall rootless docker
   become: false
   command: /usr/bin/dockerd-rootless-setuptool.sh uninstall --force
-  when: docker_rootless == false
+  when: docker_rootless == false and rootless_conf.stat.exists
 
 - name: Ensure Docker is started and enabled at boot
   service:


### PR DESCRIPTION
Here is a fairly complete "Rootless Docker" setup. 

One can toggle between both root Docker and rootless Docker by re-running the role with `docker_rootless` set to either `true` or `false`

I maintain idempotency when running `command` tags so that we don't run the `docker-rootless-setuptool.sh < install | uninstall >` unnecessarily. 

There are a couple things that I didn't get to, and don't see much value in solving for this PR:
1. This code doesn't support rootless docker in RHEL/CentOS 7 because both are end of life and I feel like trying to get them to work may overcomplicate the code a bit.
2. I chose not to install fuse-overlayfs, or any of its counterparts, despite it being recommended by the docs.  Once again, I feel like this would have overcomplicated things a bit. It's only recommended Docker, and not a strict dependency anyways.

Ultimately, I have tested this thoroughly on Ubuntu and it should work on the latest version of RHEL, however I can't test because I don't have a RHEL subscription.

I'd say having this support one OS, is better than supporting none.  Let me know if you'd like any changes made, @geerlingguy 

Fixes #412 

Update: I've confirmed that this process works on CentOS Stream 9