### PR TITLE
APT key: don't force and provide checksum, to fix check mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_key_checksum: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -31,7 +31,8 @@
     url: "{{ docker_apt_gpg_key }}"
     dest: /etc/apt/trusted.gpg.d/docker.asc
     mode: '0644'
-    force: true
+    force: false
+    checksum: "{{ docker_apt_gpg_key_checksum | default(omit) }}"
   register: add_repository_key
   ignore_errors: "{{ docker_apt_ignore_key_error }}"
   when: docker_add_repo | bool


### PR DESCRIPTION
As described in https://github.com/ansible/ansible/issues/65687, get_url only partially supports check_mode: "the changed status will reflect comparison to an empty source file".

Before this change, executing this code, with the key already being in place on the target system, would report "OK", while check_mode would report "changed".

Due to this change, both now either report "OK" or "changed", depending on the state of the target system.