### PR TITLE
remove runc, as it conflicts with containerd

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -44,6 +44,11 @@
 
 - name: Configure containerd on RHEL 8.
   block:
+    - name: Ensure runc is not installed.
+      package:
+        name: runc
+        state: absent
+
     - name: Ensure container-selinux is installed.
       package:
         name: container-selinux


### PR DESCRIPTION
On RedHat operating systems, runc is provided by default on some installations. This other container implementation conflicts with containerd, making installation impossible without removing it first.

This PR ensures runc is not installed prior to installing containerd so it doesn't fail due to this conflict.