### PR TITLE
fix: fix failure for the initial gpg key load on Pop!_OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_distribution in ['Pop!_
 docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
 docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
-docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_gpg_key_checksum: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"
 docker_apt_filename: "docker"
 


### PR DESCRIPTION
Hi, this is a follow-up PR for #396.

The previous PR fixed `docker_apt_repository` issue by using `docker_apt_ansible_distribution`, but we also needed it in `docker_apt_gpg_key`.

This gpg key needs to be added only once, so I assume the previous environment already had the gpg key for Ubuntu installed in the system.

**Additional info: error logs without this change on the latest role (v7.0.1):**

```shell
(...)

TASK [geerlingguy.docker : Load OS-specific vars.] *****************************
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/main.yml:2
ok: [localhost] => {"ansible_facts": {}, "ansible_included_var_files": ["/home/shuuji3/.ansible/roles/geerlingguy.docker/vars/main.yml"], "changed": false}

TASK [geerlingguy.docker : include_tasks] **************************************
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/main.yml:13
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [geerlingguy.docker : include_tasks] **************************************
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/main.yml:16
included: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml for localhost

TASK [geerlingguy.docker : Ensure old versions of Docker are not installed.] ***
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:2
ok: [localhost] => {"changed": false}

TASK [geerlingguy.docker : Ensure dependencies are installed.] *****************
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:9
ok: [localhost] => {"cache_update_time": 1696254271, "cache_updated": false, "changed": false}

TASK [geerlingguy.docker : Ensure additional dependencies are installed (on Ubuntu < 20.04 and any other systems).] ***
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:17
ok: [localhost] => {"cache_update_time": 1696254271, "cache_updated": false, "changed": false}

TASK [geerlingguy.docker : Ensure additional dependencies are installed (on Ubuntu >= 20.04).] ***
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:23
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [geerlingguy.docker : Add Docker apt key.] ********************************
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:29
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/etc/apt/trusted.gpg.d/docker.asc", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://download.docker.com/linux/pop!_os/gpg"}
...ignoring

TASK [geerlingguy.docker : Ensure curl is present (on older systems without SNI).] ***
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:40
ok: [localhost] => {"cache_update_time": 1696254271, "cache_updated": false, "changed": false}

TASK [geerlingguy.docker : Add Docker apt key (alternative for older systems without SNI).] ***
task path: /home/shuuji3/.ansible/roles/geerlingguy.docker/tasks/setup-Debian.yml:44
[WARNING]: Consider using the get_url or uri module rather than running 'curl'.
If you need to use command because get_url or uri is insufficient you can add
'warn: false' to this command task or set 'command_warnings=False' in
ansible.cfg to get rid of this message.
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "curl -sSL https://download.docker.com/linux/pop!_os/gpg | apt-key add -\n", "delta": "0:00:00.238957", "end": "2023-10-02 22:56:13.330414", "msg": "non-zero return code", "rc": 2, "start": "2023-10-02 22:56:13.091457", "stderr": "Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).\ngpg: no valid OpenPGP data found.", "stderr_lines": ["Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).", "gpg: no valid OpenPGP data found."], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************
localhost                  : ok=15   changed=1    unreachable=0    failed=1    skipped=5    rescued=0    ignored=1   

make: *** [/home/shuuji3/dev/ansible-setup-env/pop_os/Makefile:4: setup] Error 2
make: Leaving directory '/home/shuuji3/dev/ansible-setup-env/pop_os'

Process finished with exit code 2
```

The role was trying to download gpg key by
```
curl -sSL https://download.docker.com/linux/pop!_os/gpg | apt-key add -
```
but it must be
```
curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
```
