### PR TITLE
Fix lookup when vars not exists error.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if vars directory exists
+  stat:
+    path: 'vars'
+  register: vars_dir
+
 - name: Load OS-specific vars.
   include_vars: "{{ lookup('first_found', params) }}"
   vars:
@@ -9,6 +14,7 @@
         - main.yml
       paths:
         - 'vars'
+  when: vars_dir.stat.exists and vars_dir.stat.isdir
 
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
When the docker.yml playbook is located in the root directory, it executes correctly due to the coincidental presence of a vars directory. 

However, moving this file into the playbooks directory results in the error “No file was found when using first_found.

```yaml
# Install docker playbook
- hosts: all
  become: yes

  vars_files:
    - ../vars/{{ env }}/docker.yml

  roles:
    - role: geerlingguy.docker
      tags:
        - docker
      when: env == 'develop'
```
