### PR TITLE
Uninstall docker.io on apt distros

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,7 @@
   package:
     name:
       - docker
+      - docker.io
       - docker-engine
     state: absent
 


### PR DESCRIPTION
Some packages (e.g amazon-ecr-credential-helper) try to pull docker.io package during installation. If such package is installed during the play before docker role, the docker service will fail to start in a very non-obvious way. 
See [this thread](https://forums.docker.com/t/ubuntu-22-04-and-5-23-0-0-1-now-fails-to-start-please-suggest-debug/134472/11) for more information