### PR TITLE
Add GPG keys to `/apt/keyrings` instead of `/apt/trusted.gpg.d`, Update task `Add Docker apt key`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ docker_apt_release_channel: stable
 # and is only necessary until Docker officially supports them.
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_distribution in ['Pop!_OS', 'Linux Mint'] else ansible_distribution }}"
 docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/keyrings/docker.gpg] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/keyrings/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_gpg_key_checksum: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ docker_apt_release_channel: stable
 # and is only necessary until Docker officially supports them.
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_distribution in ['Pop!_OS', 'Linux Mint'] else ansible_distribution }}"
 docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/keyrings/docker.gpg] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_gpg_key_checksum: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -33,13 +33,16 @@
     state: directory
     mode: '0755'
 
-- name: Ensure curl is present
-  package: name=curl state=present
-
-- name: Add Docker apt key
-  shell: >
-    curl -fsSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
-  changed_when: false
+- name: Add Docker apt key.
+  ansible.builtin.get_url:
+    url: "{{ docker_apt_gpg_key }}"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+    force: false
+    checksum: "{{ docker_apt_gpg_key_checksum | default(omit) }}"
+  register: add_repository_key
+  ignore_errors: "{{ docker_apt_ignore_key_error }}"
+  when: docker_add_repo | bool
 
 - name: Change permissions for /etc/apt/keyrings/docker.gpg
   file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -39,6 +39,7 @@
 - name: Add Docker apt key 
   shell: >
     curl -fsSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
+  changed_when: false
 
 - name: Change permissions for /etc/apt/keyrings/docker.gpg 
   file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -44,10 +44,14 @@
   ignore_errors: "{{ docker_apt_ignore_key_error }}"
   when: docker_add_repo | bool
 
-- name: Change permissions for /etc/apt/keyrings/docker.gpg
-  file:
-    path: /etc/apt/keyrings/docker.gpg
-    mode: 'a+r'
+- name: Ensure curl is present (on older systems without SNI).
+  package: name=curl state=present
+  when: add_repository_key is failed and docker_add_repo | bool
+
+- name: Add Docker apt key (alternative for older systems without SNI).
+  shell: >
+    curl -sSL {{ docker_apt_gpg_key }} | apt-key add -
+  when: add_repository_key is failed and docker_add_repo | bool
 
 - name: Add Docker repository.
   apt_repository:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,25 +27,23 @@
     state: present
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')
 
-- name: Add Docker apt key.
-  ansible.builtin.get_url:
-    url: "{{ docker_apt_gpg_key }}"
-    dest: /etc/apt/trusted.gpg.d/docker.asc
-    mode: '0644'
-    force: false
-    checksum: "{{ docker_apt_gpg_key_checksum | default(omit) }}"
-  register: add_repository_key
-  ignore_errors: "{{ docker_apt_ignore_key_error }}"
-  when: docker_add_repo | bool
+- name: Ensure directory exists for /etc/apt/keyrings
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
 
-- name: Ensure curl is present (on older systems without SNI).
+- name: Ensure curl is present
   package: name=curl state=present
-  when: add_repository_key is failed and docker_add_repo | bool
 
-- name: Add Docker apt key (alternative for older systems without SNI).
+- name: Add Docker apt key 
   shell: >
-    curl -sSL {{ docker_apt_gpg_key }} | apt-key add -
-  when: add_repository_key is failed and docker_add_repo | bool
+    curl -sSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
+
+- name: Change permissions for /etc/apt/keyrings/docker.gpg 
+  file:
+    path: /etc/apt/keyrings/docker.gpg
+    mode: 'a+r'
 
 - name: Add Docker repository.
   apt_repository:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -38,7 +38,7 @@
 
 - name: Add Docker apt key 
   shell: >
-    curl -sSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
+    curl -fsSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
 
 - name: Change permissions for /etc/apt/keyrings/docker.gpg 
   file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -36,12 +36,12 @@
 - name: Ensure curl is present
   package: name=curl state=present
 
-- name: Add Docker apt key 
+- name: Add Docker apt key
   shell: >
     curl -fsSL {{ docker_apt_gpg_key }} | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
   changed_when: false
 
-- name: Change permissions for /etc/apt/keyrings/docker.gpg 
+- name: Change permissions for /etc/apt/keyrings/docker.gpg
   file:
     path: /etc/apt/keyrings/docker.gpg
     mode: 'a+r'


### PR DESCRIPTION
https://github.com/geerlingguy/ansible-role-docker/issues/435

I started this issue because I faced a similar problem as https://github.com/geerlingguy/ansible-role-docker/issues/434
when adding the docker apt repository
`Signed-By regarding source https://download.docker.com/linux/ubuntu/ jammy:
│ /etc/apt/trusted.gpg.d/docker.asc != ,`
Which I then had to fix by:
```
sudo rm /etc/apt/sources.list.d/docker.list
sudo rm /etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list
```
and then running the changes in this branch.

I did some research and noticed that GPG keys should not be placed in `/etc/apt/trusted.gpg.d/` (please see https://github.com/geerlingguy/ansible-role-docker/issues/435)

After updating the tasks to mirror the installation method in https://docs.docker.com/engine/install/debian/#install-using-the-repository, I was still getting an error:
```
W: GPG error: https://download.docker.com/linux/ubuntu jammy InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8
E: The repository 'https://download.docker.com/linux/ubuntu jammy InRelease' is not signed.
```
until I noticed that the task here https://github.com/geerlingguy/ansible-role-docker/blob/8ff4a241477f5f24c718d606a2ee450b370cc47c/tasks/setup-Debian.yml#L30
was saving the GPG key in binary whereas in the docker docs, the key is converted to an ASCII-encoded format.

I updated the ansible tasks to use the fallback curl/shell method and added a few more tasks to mirror the installation method of the docker docs.

With these changes, I'm not getting any errors and able to successfully run the role on version 7.0.2.

@geerlingguy (or any maintainer) Please let me know what you think of these changes:
1. whether the GPG keys should be saved to `/etc/apt/keyrings` (as per docker) or `/usr/share/keyrings` (as per debian)
2. If the tasks proposed in this PR are sufficient
If using the task `ansible.builtin.get_url` is preferred, I believe a task like this might be required as well directly afterwards:
```
- name: Dearmor Docker GPG key
  ansible.builtin.command: gpg --dearmor /etc/apt/keyrings/docker.gpg
``` 