### PR TITLE
Update README.md due to docker-py issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Many users of this role wish to also use Ansible to then _build_ Docker images a
 
   vars:
     pip_install_packages:
-      - name: docker
+      - name: "docker < 7.0.0"
 
   roles:
     - geerlingguy.pip


### PR DESCRIPTION
https://github.com/docker/docker-py/issues/3194/ forces downgrade to docker 6.1.3.

Readme update only. Maybe link to the issue in the readme as well, but i thought that was overkill.