### PR TITLE
add daemon_reload at start

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,7 @@
     name: docker
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
+    daemon_reload: true
   ignore_errors: "{{ ansible_check_mode }}"
   when: docker_service_manage | bool
 


### PR DESCRIPTION
Related to issue [#441](https://github.com/geerlingguy/ansible-role-docker/issues/441)

With the reload option, we can use the role after an unistallation of docker packages.