### PR TITLE
Add docker-buildx-plugin to docker_packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ docker_packages:
   - "docker-{{ docker_edition }}-cli"
   - "docker-{{ docker_edition }}-rootless-extras"
   - "containerd.io"
+  - docker-buildx-plugin
 docker_packages_state: present
 
 # Service options.


### PR DESCRIPTION
As of [Docker Engine 23.0](https://docs.docker.com/engine/release-notes/23.0/), `docker-buildx-plugin` is distributed as a separate package, so adding it to the packages list to be installed.