### PR TITLE
Fix default compose install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You can control whether the package is installed, uninstalled, or at the latest 
 
 Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set `docker_service_manage` to `false`.
 
-    docker_install_compose_plugin: false
+    docker_install_compose_plugin: true
     docker_compose_package: docker-compose-plugin
     docker_compose_package_state: present
 
 Docker Compose Plugin installation options. These differ from the below in that docker-compose is installed as a docker plugin (and used with `docker compose`) instead of a standalone binary.
 
-    docker_install_compose: true
+    docker_install_compose: false
     docker_compose_version: "1.26.0"
     docker_compose_arch: "{{ ansible_architecture }}"
     docker_compose_path: /usr/local/bin/docker-compose


### PR DESCRIPTION
In https://github.com/geerlingguy/ansible-role-docker/commit/c3a127134d6bde44bdd57fa1be1751f77d887614 the default docker compose installation was changed. This PR updates the README accordingly. 