### PR TITLE
gnupg no longer prerequisite

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -19,18 +19,6 @@
     state: present
   when: docker_add_repo | bool
 
-- name: Ensure additional dependencies are installed (on Ubuntu < 20.04 and any other systems).
-  apt:
-    name: gnupg2
-    state: present
-  when: ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('20.04', '<')
-
-- name: Ensure additional dependencies are installed (on Ubuntu >= 20.04).
-  apt:
-    name: gnupg
-    state: present
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')
-
 - name: Ensure directory exists for /etc/apt/keyrings
   file:
     path: /etc/apt/keyrings


### PR DESCRIPTION
See https://github.com/docker/docker-install/pull/391 and https://github.com/docker/docker-install/commit/811f32afe518ae963d13ff92a1bcb0a40c80eb3a.

Also https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution