### PR TITLE
Remove trusted.gpg.d artifacts.

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,17 @@
 ---
+- name: Ensure apt key is not present in trusted.gpg.d
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/docker.asc
+    state: absent
+
+- name: Ensure the repo referencing the previous trusted.gpg.d key is not present
+  apt_repository:
+    repo: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+    state: absent
+    filename: "{{ docker_apt_filename }}"
+    update_cache: true
+  when: docker_add_repo | bool
+
 - # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
   name: Ensure old versions of Docker are not installed.
   package:


### PR DESCRIPTION
Fixes https://github.com/geerlingguy/ansible-role-docker/issues/460

https://github.com/geerlingguy/ansible-role-docker/pull/436 introduced a change to the path where the apt key was placed, and to the associated repository listing in `/etc/apt/sources.d/docker.list`. We've just run into a problem with this approach, as detailed in the issue I raised, https://github.com/geerlingguy/ansible-role-docker/issues/460.

So that other people who use the role without pinning a specific version don't run into this same problem, I thought it would be wise to add a couple of tasks which remove any artifacts associated with the previous approach to storing repository keys.

I'm sorry to ping you both, @kawadeomkar / @geerlingguy, but I wonder if you would give this some consideration?