### PR TITLE
Allow change obsolete packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,13 @@ docker_packages:
   - "docker-{{ docker_edition }}-rootless-extras"
   - "containerd.io"
   - docker-buildx-plugin
+docker_obsolete_packages:
+  - docker
+  - docker.io
+  - docker-engine
+  - podman-docker
+  - containerd
+  - runc
 docker_packages_state: present
 
 # Service options.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,13 +2,7 @@
 - # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
   name: Ensure old versions of Docker are not installed.
   package:
-    name:
-      - docker
-      - docker.io
-      - docker-engine
-      - podman-docker
-      - containerd
-      - runc
+    name: "{{ docker_obsolete_packages }}"
     state: absent
 
 - name: Ensure dependencies are installed.


### PR DESCRIPTION
There are some reason (religion, company policy) to force install package from distribution.
We can done that with right parameters (ubuntu 22.04):

    - name: Include geerlingguy.docker role
      ansible.builtin.include_role:
        name: geerlingguy.docker
      vars:
        docker_add_repo: false
        docker_packages:
          - docker.io
          - containerd
        docker_compose_package: docker-compose-v2
        docker_obsolete_packages: []

But the role want to remove old versions of Docker, and this remove the distrib packages too.

This patch allow change the list of package to remove.