### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A list of system users to be added to the `docker` group (so they can use Docker
 
 ```yaml
 docker_daemon_options:
-  storage-driver: "devicemapper"
+  storage-driver: "overlay2"
   log-opts:
     max-size: "100m"
 ```


### PR DESCRIPTION
Saw some errors in my install that devicemapper was deprecated and that overlay2 is the recommended default: https://docs.docker.com/engine/storage/drivers/select-storage-driver/