### PR TITLE
Update variables to support Kali Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,6 @@ docker_apt_release_channel: stable
 # docker_apt_ansible_distribution is a workaround for Ubuntu variants which can't be identified as such by Ansible,
 # and is only necessary until Docker officially supports them.
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else 'debian' if ansible_facts.distribution in ['Kali'] else ansible_facts.distribution }}"
-docker_apt_ansible_distribution_release: "{{ 'trixie' if ansible_facts.distribution in ['Kali'] else ansible_facts.distribution_release }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,11 +44,12 @@ docker_add_repo: true
 # Docker repo URL.
 docker_repo_url: https://download.docker.com/linux
 
-# Used only for Debian/Ubuntu/Pop!_OS/Linux Mint. Switch 'stable' to 'nightly' if needed.
+# Used only for Debian/Kali/Ubuntu/Pop!_OS/Linux Mint. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
 # docker_apt_ansible_distribution is a workaround for Ubuntu variants which can't be identified as such by Ansible,
 # and is only necessary until Docker officially supports them.
-docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
+docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else 'debian' if ansible_facts.distribution in ['Kali'] else ansible_facts.distribution }}"
+docker_apt_ansible_distribution_release: "{{ 'trixie' if ansible_facts.distribution in ['Kali'] else ansible_facts.distribution_release }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,12 +27,31 @@
       - python3-debian
     state: present
 
+# Kali has no local method of determining its Debian codename. This wouldn't be reliable anyway,
+# as "stable" is often what package maintainers develop for, and Kali is based on "debian-testing".
+- name: Obtain Debian stable's codename
+  ansible.builtin.uri:
+    url: https://ftp.debian.org/debian/dists/stable/Release
+    return_content: true
+  register: debian_release
+  until: debian_release.status == 200
+  retries: 5 # Retry a total of 5 times
+  delay: 30 # Every 30 seconds, meaning try 5 times in 2.5 minutes
+  failed_when: "debian_release is failed or 'Codename' not in debian_release.content"
+  when: ansible_facts.distribution == 'Kali'
+
+# https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/regex_search_filter.html#examples
+- name: Set Debian stable's codename for Kali
+  ansible.builtin.set_fact:
+    debian_codename: "{{ (debian_release.content | regex_search('^Codename: (\\w+)$', '\\1', multiline=True))[0] }}"
+  when: ansible_facts.distribution == 'Kali'
+
 - name: Add or remove Docker repository.
   ansible.builtin.deb822_repository:
     name: "{{ docker_apt_filename }}"
     types: deb
     uris: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
-    suites: "{{ docker_apt_ansible_distribution_release }}"
+    suites: "{{ debian_codename if ansible_facts.distribution == 'Kali' else ansible_facts.distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"
     state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,7 +32,7 @@
     name: "{{ docker_apt_filename }}"
     types: deb
     uris: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
-    suites: "{{ ansible_facts.distribution_release }}"
+    suites: "{{ docker_apt_ansible_distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"
     state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"


### PR DESCRIPTION
After seeing how Pop!_OS and Linux Mint were supported, it looks like the same can be done for Kali using a separate variable for the release string here:

```yml
docker_apt_ansible_distribution_release: "{{ 'bookworm' if ansible_distribution in ['Kali'] else ansible_distribution_release }}"
```

...and replacing the few instances of `ansible_distribution_release` with that new variable. 

There may be a better way to do this since `bookworm` will need updated with each [Debian major release](https://www.debian.org/releases/). However it's infrequent enough that it may be acceptable for now, similar to the GPG key checksum being a static value.