### PR TITLE
Add `docker-doc` to default obsolete packages list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker_obsolete_packages:
   - docker
   - docker.io
   - docker-engine
+  - docker-doc
   - podman-docker
   - containerd
   - runc

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ docker_obsolete_packages:
   - docker
   - docker.io
   - docker-engine
+  - docker-doc
   - podman-docker
   - containerd
   - runc


### PR DESCRIPTION
is included in [docs](https://docs.docker.com/engine/install/debian/#uninstall-old-versions)