### PR TITLE
update depricated 303 rule, add name[missing] rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,37 @@ Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>` (Note: you have to add th
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_packages_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
 ```yaml
-docker_obsolete_packages:
+# Used only for Debian/Ubuntu
+docker_obsolete_packages_debian:
   - docker
   - docker.io
   - docker-engine
   - docker-doc
+  - docker-compose
+  - docker-compose-v2
   - podman-docker
   - containerd
   - runc
+
+# Used only for Fedora/CentOS/Rocky
+docker_obsolete_packages_redhat:
+  - docker
+  - docker-client
+  - docker-client-latest
+  - docker-common
+  - docker-latest
+  - docker-latest-logrotate
+  - docker-logrotate
+  - docker-selinux
+  - docker-engine-selinux
+  - docker-engine
 ```
 
-A list of packages to be uninstalled prior to running this role. See [Docker's installation instructions](https://docs.docker.com/engine/install/debian/#uninstall-old-versions) for an up-to-date list of old packages that should be removed.
+A list of packages to be uninstalled prior to running this role. See Docker's installation instructions for an up-to-date list of old packages that should be removed:
+
+- [Docker's installation instructions - Debian](https://docs.docker.com/engine/install/debian/#uninstall-old-versions)
+- [Docker's installation instructions - Fedora](https://docs.docker.com/engine/install/fedora/#uninstall-old-versions)
+
 
 ```yaml
 docker_service_manage: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can control whether the package is installed, uninstalled, or at the latest 
 
 ```yaml
 # Used only for Debian/Ubuntu
-docker_obsolete_packages_debian:
+docker_obsolete_packages:
   - docker
   - docker.io
   - docker-engine
@@ -41,19 +41,6 @@ docker_obsolete_packages_debian:
   - podman-docker
   - containerd
   - runc
-
-# Used only for Fedora/CentOS/Rocky
-docker_obsolete_packages_redhat:
-  - docker
-  - docker-client
-  - docker-client-latest
-  - docker-common
-  - docker-latest
-  - docker-latest-logrotate
-  - docker-logrotate
-  - docker-selinux
-  - docker-engine-selinux
-  - docker-engine
 ```
 
 A list of packages to be uninstalled prior to running this role. See Docker's installation instructions for an up-to-date list of old packages that should be removed:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Debian/Ubuntu: `docker-{{ docker_edition }}=<VERSION>` (Note: you have to add th
 You can control whether the package is installed, uninstalled, or at the latest version by setting `docker_packages_state` to `present`, `absent`, or `latest`, respectively. Note that the Docker daemon will be automatically restarted if the Docker package is updated. This is a side effect of flushing all handlers (running any of the handlers that have been notified by this and any other role up to this point in the play).
 
 ```yaml
-# Used only for Debian/Ubuntu
 docker_obsolete_packages:
   - docker
   - docker.io
@@ -43,11 +42,10 @@ docker_obsolete_packages:
   - runc
 ```
 
-A list of packages to be uninstalled prior to running this role. See Docker's installation instructions for an up-to-date list of old packages that should be removed:
+`docker_obsolete_packages` for different os-family linux distributions:
 
-- [Docker's installation instructions - Debian](https://docs.docker.com/engine/install/debian/#uninstall-old-versions)
-- [Docker's installation instructions - Fedora](https://docs.docker.com/engine/install/fedora/#uninstall-old-versions)
-
+- [`RedHat.yaml`](./vars/RedHat.yml), [obsolete packages](https://docs.docker.com/engine/install/fedora/#uninstall-old-versions)
+- [`Debian.yaml`](./vars/Debian.yml), [obsolete packages](https://docs.docker.com/engine/install/debian/#uninstall-old-versions)
 
 ```yaml
 docker_service_manage: true
@@ -106,7 +104,7 @@ Usually in combination with changing `docker_apt_repository` as well. `docker_ap
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 ```
 
 (Used only for RedHat/CentOS.) You can enable the Nightly or Test repo by setting the respective vars to `1`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,17 +21,6 @@ docker_obsolete_packages_debian:
   - containerd
   - runc
 
-# Used only for Fedora/CentOS/Rocky
-docker_obsolete_packages_redhat:
-  - docker
-  - docker-client
-  - docker-client-latest
-  - docker-common
-  - docker-latest
-  - docker-latest-logrotate
-  - docker-logrotate
-  - docker-engine
-
 # Service options.
 docker_service_manage: true
 docker_service_state: started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,14 +8,29 @@ docker_packages:
   - "containerd.io"
   - docker-buildx-plugin
 docker_packages_state: present
-docker_obsolete_packages:
+
+# Used only for Debian/Ubuntu
+docker_obsolete_packages_debian:
   - docker
   - docker.io
   - docker-engine
   - docker-doc
+  - docker-compose
+  - docker-compose-v2
   - podman-docker
   - containerd
   - runc
+
+# Used only for Fedora/CentOS/Rocky
+docker_obsolete_packages_redhat:
+  - docker
+  - docker-client
+  - docker-client-latest
+  - docker-common
+  - docker-latest
+  - docker-latest-logrotate
+  - docker-logrotate
+  - docker-engine
 
 # Service options.
 docker_service_manage: true
@@ -57,7 +72,7 @@ docker_apt_filename: "docker"
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 
 # A list of users who will be added to the docker group.
 docker_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ docker_packages:
 docker_packages_state: present
 
 # Used only for Debian/Ubuntu
-docker_obsolete_packages_debian:
+docker_obsolete_packages:
   - docker
   - docker.io
   - docker-engine

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
-    - name: Wait for systemd to complete initialization.  # noqa 303
+    - name: Wait for systemd to complete initialization.  # noqa: command-instead-of-module
       command: systemctl is-system-running
       register: systemctl_status
       until: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,16 @@
   vars:
     params:
       files:
-        - '{{ansible_distribution}}.yml'
-        - '{{ansible_os_family}}.yml'
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
         - main.yml
       paths:
         - 'vars'
 
-- include_tasks: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml # noqa: name[missing]
   when: ansible_os_family == 'RedHat'
 
-- include_tasks: setup-Debian.yml
+- include_tasks: setup-Debian.yml # noqa: name[missing]
   when: ansible_os_family == 'Debian'
 
 - name: Install Docker packages.
@@ -76,7 +76,7 @@
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers
 
-- include_tasks: docker-compose.yml
+- include_tasks: docker-compose.yml # noqa: name[missing]
   when: docker_install_compose | bool
 
 - name: Get docker group info using getent.
@@ -94,5 +94,5 @@
     - item not in ansible_facts.getent_group["docker"][2]
   with_items: "{{ docker_users }}"
 
-- include_tasks: docker-users.yml
+- include_tasks: docker-users.yml # noqa: name[missing]
   when: at_least_one_user_to_modify is defined

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,7 +20,7 @@
 - # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
   name: Ensure old versions of Docker are not installed.
   ansible.builtin.package:
-    name: "{{ docker_obsolete_packages_debian }}"
+    name: "{{ docker_obsolete_packages }}"
     state: absent
 
 - name: Ensure dependencies are installed.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -19,8 +19,8 @@
 
 - # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
   name: Ensure old versions of Docker are not installed.
-  package:
-    name: "{{ docker_obsolete_packages }}"
+  ansible.builtin.package:
+    name: "{{ docker_obsolete_packages_debian }}"
     state: absent
 
 - name: Ensure dependencies are installed.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,7 +3,7 @@
 # or  https://docs.docker.com/engine/install/centos/#uninstall-old-versions
 - name: Ensure old versions of Docker are not installed.
   ansible.builtin.package:
-    name: "{{ docker_obsolete_packages_redhat }}"
+    name: "{{ docker_obsolete_packages }}"
     state: absent
 
 - name: Add Docker GPG key.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,10 +1,9 @@
 ---
+# See https://docs.docker.com/engine/install/fedora/#uninstall-old-versions
+# or  https://docs.docker.com/engine/install/centos/#uninstall-old-versions
 - name: Ensure old versions of Docker are not installed.
-  package:
-    name:
-      - docker
-      - docker-common
-      - docker-engine
+  ansible.builtin.package:
+    name: "{{ docker_obsolete_packages_redhat }}"
     state: absent
 
 - name: Add Docker GPG key.

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,11 @@
+# Used only for Debian/Ubuntu
+docker_obsolete_packages:
+  - docker
+  - docker.io
+  - docker-engine
+  - docker-doc
+  - docker-compose
+  - docker-compose-v2
+  - podman-docker
+  - containerd
+  - runc

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,4 @@
+---
 # Used only for Debian/Ubuntu
 docker_obsolete_packages:
   - docker

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,10 @@
+# Used only for Fedora/CentOS/Rocky
+docker_obsolete_packages:
+  - docker
+  - docker-client
+  - docker-client-latest
+  - docker-common
+  - docker-latest
+  - docker-latest-logrotate
+  - docker-logrotate
+  - docker-engine

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,4 @@
+---
 # Used only for Fedora/CentOS/Rocky
 docker_obsolete_packages:
   - docker


### PR DESCRIPTION
Changes:

- Update deprecated `303` rule in `molecule/default/converge.yml`
- Also add `# noqa: name[missing]` to prevent redundancy tasks name.
- add spaces around `ansible_distribution` and `ansible_os_family` in `tasks/main.yml` for `Load OS-specific vars`

`ansible-lint` Errors and Warnings:

```text
warning[outdated-tag]: Replaced outdated tag '303' with 'command-instead-of-module', replace it to avoid future errors
```

```text
name[missing]: All tasks should be named.
```
