### PR TITLE
Update setup-RedHat.yml

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,10 +1,8 @@
 ---
-- name: Ensure old versions of Docker are not installed.
+- # See https://docs.docker.com/engine/install/rhel/#uninstall-old-versions
+  name: Ensure old versions of Docker are not installed.
   package:
-    name:
-      - docker
-      - docker-common
-      - docker-engine
+    name: "{{ docker_obsolete_packages }}"
     state: absent
 
 - name: Add Docker GPG key.


### PR DESCRIPTION
obsolete packages must be removed or install will fail, 

this will allow users to over ride
docker_obsolete_packages from the default values ( used for debian ).

Maybe in future can add smarts about the default values depending on OS

https://docs.docker.com/engine/install/rhel/#uninstall-old-versions

docker \
                  docker-client \
                  docker-client-latest \
                  docker-common \
                  docker-latest \
                  docker-latest-logrotate \
                  docker-logrotate \
                  docker-engine \
                  podman \
                  runc