### PR TITLE
fix: issue with #470 fix

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure old apt source list is not present in /etc/apt/sources.list.d
   ansible.builtin.file:
-    path: /etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list
+    path: "/etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution }}.list"
     state: absent
 
 - name: Ensure the repo referencing the previous trusted.gpg.d key is not present


### PR DESCRIPTION
This patch ensures that the correct filename is specified based on the distribution. Observed this behaviour on a Debian system, the old file was not removed due to it being hardcoded to ubuntu instead.

Corrects an issue introduced in #477 