### PR TITLE
Add deb822 format for repository source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Controls whether this role will add the official Docker repository. Set to `fals
 
 For any instance running Ubuntu 24.04 or later, the Docker repository source file will be in `deb822` format by default.
 
-This behavior can be modified using the `docker_deb822_format` variable. For example, if the one-line format is preferred, set the variable as follows:
+This behavior can be modified using the `docker_apt_deb822_format` variable. For example, if the one-line format is preferred, set the variable as follows:
 
 ```yaml
-docker_deb822_format: false
+docker_apt_deb822_format: false
 ```
 
 When set to `true`, the `deb822` format will be used for all Debian-based installations. Note that enabling this will also remove any existing `docker.list` file and install `python3-debian`.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ docker_add_repo: true
 
 Controls whether this role will add the official Docker repository. Set to `false` if you want to use the default docker packages for your system or manage the package repository on your own.
 
+For any instance running Ubuntu 24.04 or later, the Docker repository source file will be in `deb822` format by default.
+
+This behavior can be modified using the `docker_deb822_format` variable. For example, if the one-line format is preferred, set the variable as follows:
+
+```yaml
+docker_deb822_format: false
+```
+
+When set to `true`, the `deb822` format will be used for all Debian-based installations. Note that enabling this will also remove any existing `docker.list` file and install `python3-debian`.
+
 ```yaml
 docker_repo_url: https://download.docker.com/linux
 ```

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,7 @@
     state: "{{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: docker_service_manage | bool
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,11 +1,11 @@
 ---
 - name: Check if deb822 format should be used and save it as a fact
   vars:
-    is_ubuntu2404_or_greater: >-
-      {{ ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>=') }}
+    is_ubuntu2304_or_greater: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('23.04', '>=') }}"
+    is_debian12_or_greater: "{{ ansible_distribution == 'Debian' and ansible_distribution_version is version('12', '>=') }}"
+    is_deb822_preferred: "{{ is_ubuntu2304_or_greater or is_debian12_or_greater }}"
   ansible.builtin.set_fact:
-    docker_use_deb822_format: >-
-      {{ docker_deb822_format | default(is_ubuntu2404_or_greater) }}
+    docker_use_deb822_format: "{{ docker_apt_deb822_format | default(is_deb822_preferred) }}"
 
 - name: Ensure apt key is not present in trusted.gpg.d
   ansible.builtin.file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,8 +1,11 @@
 ---
-- name: Check if the distribution is Ubuntu 24.04 or later and save it as a fact
-  ansible.builtin.set_fact:
+- name: Check if deb822 format should be used and save it as a fact
+  vars:
     is_ubuntu2404_or_greater: >-
       {{ ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>=') }}
+  ansible.builtin.set_fact:
+    docker_use_deb822_format: >-
+      {{ docker_deb822_format | default(is_ubuntu2404_or_greater) }}
 
 - name: Ensure apt key is not present in trusted.gpg.d
   ansible.builtin.file:
@@ -13,7 +16,7 @@
   vars:
     old_apt_source_list_files:
       - /etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution }}.list
-      - "{{ is_ubuntu2404_or_greater | ansible.builtin.ternary('/etc/apt/sources.list.d/docker.list', '') }}"
+      - "{{ docker_use_deb822_format | ansible.builtin.ternary('/etc/apt/sources.list.d/docker.list', '') }}"
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -38,7 +41,7 @@
     dependencies:
       - apt-transport-https
       - ca-certificates
-      - "{{ is_ubuntu2404_or_greater | ansible.builtin.ternary('python3-debian', '') }}"
+      - "{{ docker_use_deb822_format | ansible.builtin.ternary('python3-debian', '') }}"
   apt:
     name: "{{ dependencies | select }}"
     state: present
@@ -78,12 +81,12 @@
     update_cache: true
   when:
     - docker_add_repo | bool
-    - ansible_distribution != "Ubuntu" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<'))
+    - not docker_use_deb822_format
 
 - name: Manage the deb822 format
   when:
     - docker_add_repo | bool
-    - is_ubuntu2404_or_greater
+    - docker_use_deb822_format
   block:
     - name: Add Docker repository with deb822 format.
       ansible.builtin.deb822_repository:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,13 +1,23 @@
 ---
+- name: Check if the distribution is Ubuntu 24.04 or later and save it as a fact
+  ansible.builtin.set_fact:
+    is_ubuntu2404_or_greater: >-
+      {{ ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>=') }}
+
 - name: Ensure apt key is not present in trusted.gpg.d
   ansible.builtin.file:
     path: /etc/apt/trusted.gpg.d/docker.asc
     state: absent
 
-- name: Ensure old apt source list is not present in /etc/apt/sources.list.d
+- name: Ensure old apt source list files are not present in /etc/apt/sources.list.d
+  vars:
+    old_apt_source_list_files:
+      - /etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution }}.list
+      - "{{ is_ubuntu2404_or_greater | ansible.builtin.ternary('/etc/apt/sources.list.d/docker.list', '') }}"
   ansible.builtin.file:
-    path: "/etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution }}.list"
+    path: "{{ item }}"
     state: absent
+  loop: "{{ old_apt_source_list_files | select }}"
 
 - name: Ensure the repo referencing the previous trusted.gpg.d key is not present
   apt_repository:
@@ -24,10 +34,13 @@
     state: absent
 
 - name: Ensure dependencies are installed.
-  apt:
-    name:
+  vars:
+    dependencies:
       - apt-transport-https
       - ca-certificates
+      - "{{ is_ubuntu2404_or_greater | ansible.builtin.ternary('python3-debian', '') }}"
+  apt:
+    name: "{{ dependencies | select }}"
     state: present
   when: docker_add_repo | bool
 
@@ -63,4 +76,25 @@
     state: present
     filename: "{{ docker_apt_filename }}"
     update_cache: true
-  when: docker_add_repo | bool
+  when:
+    - docker_add_repo | bool
+    - ansible_distribution != "Ubuntu" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<'))
+
+- name: Manage the deb822 format
+  when:
+    - docker_add_repo | bool
+    - is_ubuntu2404_or_greater
+  block:
+    - name: Add Docker repository with deb822 format.
+      ansible.builtin.deb822_repository:
+        name: "{{ docker_apt_filename }}"
+        types: deb
+        uris: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}"
+        suites: "{{ ansible_distribution_release }}"
+        components: "{{ docker_apt_release_channel }}"
+        signed_by: /etc/apt/keyrings/docker.asc
+        architectures: "{{ docker_apt_arch }}"
+      notify: Update apt cache
+
+    - name: Ensure handlers are notified immediately to update the apt cache.
+      ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Recently, I upgraded a series of VMs from Ubuntu 22.04 to 24.04; Docker had been installed on all of them using this role.  

After completing the upgrade, I noticed that the `/etc/apt/sources.list.d/` directory contained the file `docker.list.distUpgrade`, which was created from the old `docker.list` (added by the role), along with `docker.sources`, a deb822-formatted file that was automatically generated.  

When I tried rerunning the role, the `docker.list` file was recreated, and on the first `apt update`, many warnings appeared because there were two files referencing the same repository:
![docker-warning](https://github.com/user-attachments/assets/f890a342-9abd-4406-ad65-dce0fb8b8aef)

Since the `deb822` format is already used with Ubuntu 24.04 and the one-line format will be deprecated in the future, would it be possible to introduce it within the role?  

I have prepared this PR for this purpose. Let me know if any changes are needed.