### PR TITLE
update: docker_yum_gpg_key variable to get the distro gpg key

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Usually in combination with changing `docker_apt_repository` as well. `docker_ap
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 ```
 
 (Used only for RedHat/CentOS.) You can enable the Nightly or Test repo by setting the respective vars to `1`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ docker_apt_filename: "docker"
 docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/centos/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 
 # A list of users who will be added to the docker group.
 docker_users: []


### PR DESCRIPTION
changes:
- update the `docker_yum_gpg_key` to get the os specific (fedora or centos) yum gpg key in `defaults/main.yml` and `README.md`, if fedora or centos gpg keys are different