### PR TITLE
Ensure the Docker daemon options file (`/etc/docker/daemon.json`) is deleted when no longer needed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,13 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Ensure the Docker daemon options file is deleted when no longer needed.
+  file:
+    path: /etc/docker/daemon.json
+    state: absent
+  when: docker_daemon_options.keys() | length == 0
+  notify: restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker


### PR DESCRIPTION
If people set options in `docker_daemon_options` (e.g. `{'ipv6': false}`), the role will create the `/etc/docker/daemon.json` file and populate it with the options.

Later on, if people stop setting *all of these* options, the file used to remain in place (containing the old options) and cause trouble. This is unexpected.

If the Docker installation is managed by this role and the `/etc/docker/daemon.json` file is managed by it, it should also take care to:

- either delete the file when it's no longer necessary
- or populate it with empty options if that is what `docker_daemon_options` contains

Deleting the file instead of putting `{}` in it seems like the cleaner approach.

There's a chance that people would like to manage options in `/etc/docker/daemon.json` by themselves (without Ansible) and this new behavior when `docker_daemon_options` is empty, but this runs against having a managed Docker installation via Ansible.

This patch only deletes the `/etc/docker/daemon.json` file.

We could possibly delete the `/etc/docker` directory too, but it's more tricky to delete it only when it's empty. In some cases, the directory may contain other files and invoking the `file` module with `state: absent` will delete everything recursively, which is undesirable.

Related to:

- https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/bd073bca742d98cd0254d2a5cf76b92a2bc60621
- https://github.com/mother-of-all-self-hosting/mash-playbook/commit/e8f220ad8600df83b14ab189391bcfb717d1a8a2