### PR TITLE
add compose package to Alpine specific variables

### DIFF
--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,2 +1,3 @@
 ---
 docker_packages: "docker"
+docker_compose_package: docker-cli-compose


### PR DESCRIPTION
Alpine uses a different package name for `docker compose` than the docker official repo's
This adds an override variable similar to what's already in place for `Archlinux.yml`