### PR TITLE
Add docker service configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ docker_daemon_options:
 
 Custom `dockerd` options can be configured through this dictionary representing the json file `/etc/docker/daemon.json`.
 
+```yaml
+docker_service_settings:
+  - HTTP_PROXY=http://proxy.example.com:80
+  - HTTPS_PROXY=https://proxy.example.com:443
+  - NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp
+```
+
+Custom docker service configuration. Should only be used for `HTTP/HTTPS proxy` settings.
+
 ## Use with Ansible (and `docker` Python library)
 
 Many users of this role wish to also use Ansible to then _build_ Docker images and manage Docker containers on the server where Docker is installed. In this case, you can easily add in the `docker` Python library using the `geerlingguy.pip` role:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,3 +66,6 @@ docker_users: []
 
 # Docker daemon options as a dict
 docker_daemon_options: {}
+
+# Docker HTTP/HTTPS proxy settings as list of environment configurations
+docker_service_settings: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,21 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Create docker config target directory
+  file: 
+    path: /etc/systemd/system/docker.service.d
+    state: directory 
+    mode: 0755
+  when: docker_service_settings | length > 0
+
+- name: Configure docker service environment.
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/docker.service.d/http-proxy.conf
+    mode: 0644
+  when: docker_service_settings | length > 0
+  notify: restart docker
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/templates/http-proxy.conf.j2
+++ b/templates/http-proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for docker_service_setting in docker_service_settings %}
+Environment="{{ docker_service_setting }}"
+{% endfor %}


### PR DESCRIPTION
Custom docker service configuration. Should only be used for `HTTP/HTTPS proxy` settings.