### PR TITLE
Included the gpg package as requirements for Debian

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,6 +9,15 @@
     path: "/etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution | lower }}.list"
     state: absent
 
+- name: Ensure dependencies are installed.
+  apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - gpg
+    state: present
+  when: docker_add_repo | bool
+
 - name: Ensure the repo referencing the previous trusted.gpg.d key is not present
   apt_repository:
     repo: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
@@ -22,15 +31,6 @@
   package:
     name: "{{ docker_obsolete_packages }}"
     state: absent
-
-- name: Ensure dependencies are installed.
-  apt:
-    name:
-      - apt-transport-https
-      - ca-certificates
-      - gpg
-    state: present
-  when: docker_add_repo | bool
 
 - name: Ensure directory exists for /etc/apt/keyrings
   file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -28,6 +28,7 @@
     name:
       - apt-transport-https
       - ca-certificates
+      - gpg
     state: present
   when: docker_add_repo | bool
 


### PR DESCRIPTION
Either the `gpg` or the `apt-key` package is required for the [`ansible.builtin.apt_repository`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html) module. Neither of them are present in debian cloud images and must be installed manually. See for example https://cloud.debian.org/images/cloud the `generic` or `genericcloud` images.

Added `gpg` to the dependencies task.