### PR TITLE
Refactor Debian setup to use deb822_repository

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,11 @@
 ---
 - name: restart docker
-  service:
+  ansible.builtin.service:
     name: docker
     state: "{{ docker_restart_handler_state }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: docker_service_manage | bool
+
+- name: apt update
+  ansible.builtin.apt:
+    update_cache: true

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -51,8 +51,3 @@
 
 - name: Ensure handlers are notified immediately to update the apt cache.
   ansible.builtin.meta: flush_handlers
-
-- name: Remove Docker apt key if docker_add_repo is false.
-  ansible.builtin.file:
-    path: /etc/apt/keyrings/docker.asc
-    state: "{{ 'file' if docker_add_repo | bool else 'absent' }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -49,6 +49,9 @@
     state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"
   notify: apt update
 
+- name: Ensure handlers are notified immediately to update the apt cache.
+  ansible.builtin.meta: flush_handlers
+
 - name: Remove Docker apt key if docker_add_repo is false.
   ansible.builtin.file:
     path: /etc/apt/keyrings/docker.asc

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,57 +10,46 @@
     state: absent
 
 - name: Ensure the repo referencing the previous trusted.gpg.d key is not present
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     state: absent
     filename: "{{ docker_apt_filename }}"
     update_cache: true
   when: docker_add_repo | bool
 
-- # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
-  name: Ensure old versions of Docker are not installed.
-  package:
+# See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
+- name: Ensure old versions of Docker are not installed.
+  ansible.builtin.package:
     name: "{{ docker_obsolete_packages }}"
     state: absent
 
+- name: Ensure legacy repo file is not present.
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/docker.list"
+    state: absent
+
 - name: Ensure dependencies are installed.
-  apt:
+  ansible.builtin.apt:
     name:
       - apt-transport-https
       - ca-certificates
+      - curl
+      - gpg
+      - python3-debian
     state: present
-  when: docker_add_repo | bool
 
-- name: Ensure directory exists for /etc/apt/keyrings
-  file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: "0755"
+- name: Add or remove Docker repository.
+  ansible.builtin.deb822_repository:
+    name: docker
+    types: deb
+    uris: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}"
+    suites: "{{ ansible_distribution_release }}"
+    components: "{{ docker_apt_release_channel }}"
+    signed_by: "{{ docker_apt_gpg_key }}"
+    state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"
+  notify: apt update
 
-- name: Add Docker apt key.
-  ansible.builtin.get_url:
-    url: "{{ docker_apt_gpg_key }}"
-    dest: /etc/apt/keyrings/docker.asc
-    mode: "0644"
-    force: false
-    checksum: "{{ docker_apt_gpg_key_checksum | default(omit) }}"
-  register: add_repository_key
-  ignore_errors: "{{ docker_apt_ignore_key_error }}"
-  when: docker_add_repo | bool
-
-- name: Ensure curl is present (on older systems without SNI).
-  package: name=curl state=present
-  when: add_repository_key is failed and docker_add_repo | bool
-
-- name: Add Docker apt key (alternative for older systems without SNI).
-  shell: >
-    curl -sSL {{ docker_apt_gpg_key }} | apt-key add -
-  when: add_repository_key is failed and docker_add_repo | bool
-
-- name: Add Docker repository.
-  apt_repository:
-    repo: "{{ docker_apt_repository }}"
-    state: present
-    filename: "{{ docker_apt_filename }}"
-    update_cache: true
-  when: docker_add_repo | bool
+- name: Remove Docker apt key if docker_add_repo is false.
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/docker.asc
+    state: "{{ 'file' if docker_add_repo | bool else 'absent' }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,14 +9,6 @@
     path: "/etc/apt/sources.list.d/download_docker_com_linux_{{ docker_apt_ansible_distribution | lower }}.list"
     state: absent
 
-- name: Ensure the repo referencing the previous trusted.gpg.d key is not present
-  ansible.builtin.apt_repository:
-    repo: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
-    state: absent
-    filename: "{{ docker_apt_filename }}"
-    update_cache: true
-  when: docker_add_repo | bool
-
 # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
 - name: Ensure old versions of Docker are not installed.
   ansible.builtin.package:
@@ -33,8 +25,6 @@
     name:
       - apt-transport-https
       - ca-certificates
-      - curl
-      - gpg
       - python3-debian
     state: present
 


### PR DESCRIPTION
- Replaces deprecated apt_repository and manual GPG key management with ansible.builtin.deb822_repository, introduced in apt 1.1.
- Updates handlers to use FQCNs.

Should be compatible with all supported Ubuntu and Debian distros. deb822 was introduced in apt 1.1.