### PR TITLE
Consistently access facts via the ansible_facts.* namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Docker Compose Plugin installation options. These differ from the below in that 
 ```yaml
 docker_install_compose: false
 docker_compose_version: "v2.32.1"
-docker_compose_arch: "{{ ansible_architecture }}"
+docker_compose_arch: "{{ ansible_facts.architecture }}"
 docker_compose_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-linux-{{ docker_compose_arch }}"
 docker_compose_path: /usr/local/bin/docker-compose
 ```
@@ -90,10 +90,10 @@ The main Docker repo URL, common between Debian and RHEL systems.
 
 ```yaml
 docker_apt_release_channel: stable
-docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }}{{' signed-by=/etc/apt/keyrings/docker.asc' if add_repository_key is not failed}}] {{ docker_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_arch: "{{ 'arm64' if ansible_facts.architecture == 'aarch64' else 'amd64' }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }}{{' signed-by=/etc/apt/keyrings/docker.asc' if add_repository_key is not failed}}] {{ docker_repo_url }}/{{ ansible_facts.distribution | lower }} {{ ansible_facts.distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: True
-docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}/gpg"
+docker_apt_gpg_key: "{{ docker_repo_url }}/{{ ansible_facts.distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 ```
 
@@ -103,10 +103,10 @@ You can change `docker_apt_gpg_key` to a different url if you are behind a firew
 Usually in combination with changing `docker_apt_repository` as well. `docker_apt_filename` controls the name of the source list file created in `sources.list.d`. If you are upgrading from an older (<7.0.0) version of this role, you should change this to the name of the existing file (e.g. `download_docker_com_linux_debian` on Debian) to avoid conflicting lists.
 
 ```yaml
-docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
+docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_facts.distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_facts.distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 ```
 
 (Used only for RedHat/CentOS.) You can enable the Nightly or Test repo by setting the respective vars to `1`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ docker_compose_package_state: present
 # Docker Compose options.
 docker_install_compose: false
 docker_compose_version: "v2.32.1"
-docker_compose_arch: "{{ ansible_architecture }}"
+docker_compose_arch: "{{ ansible_facts.architecture }}"
 docker_compose_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-linux-{{ docker_compose_arch }}"
 docker_compose_path: /usr/local/bin/docker-compose
 
@@ -47,19 +47,19 @@ docker_repo_url: https://download.docker.com/linux
 docker_apt_release_channel: stable
 # docker_apt_ansible_distribution is a workaround for Ubuntu variants which can't be identified as such by Ansible,
 # and is only necessary until Docker officially supports them.
-docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_distribution in ['Pop!_OS', 'Linux Mint'] else ansible_distribution }}"
-docker_apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'armhf' if ansible_architecture == 'armv7l' else 'amd64' }}"
-docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/keyrings/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
+docker_apt_arch: "{{ 'arm64' if ansible_facts.architecture == 'aarch64' else 'armhf' if ansible_facts.architecture == 'armv7l' else 'amd64' }}"
+docker_apt_repository: "deb [arch={{ docker_apt_arch }} signed-by=/etc/apt/keyrings/docker.asc] {{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }} {{ ansible_facts.distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_gpg_key_checksum: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"
 docker_apt_filename: "docker"
 
 # Used only for RedHat/CentOS/Fedora.
-docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
+docker_yum_repo_url: "{{ docker_repo_url }}/{{ (ansible_facts.distribution == 'Fedora') | ternary('fedora','centos') }}/docker-{{ docker_edition }}.repo"
 docker_yum_repo_enable_nightly: '0'
 docker_yum_repo_enable_test: '0'
-docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
+docker_yum_gpg_key: "{{ docker_repo_url }}/{{ (ansible_facts.distribution == 'Fedora') | ternary('fedora', 'centos') }}/gpg"
 
 # A list of users who will be added to the docker group.
 docker_users: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
     - name: Wait for systemd to complete initialization.  # noqa 303
       command: systemctl is-system-running
@@ -16,7 +16,7 @@
         'degraded' in systemctl_status.stdout
       retries: 30
       delay: 5
-      when: ansible_service_mgr == 'systemd'
+      when: ansible_facts.service_mgr == 'systemd'
       changed_when: false
       failed_when: systemctl_status.rc > 1
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,8 +17,5 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      inject_facts_as_vars: false
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,5 +17,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      inject_facts_as_vars: false
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,14 +17,14 @@
     - name: Verify Docker service is running
       command: systemctl is-active docker
       register: docker_service_status
-      when: ansible_service_mgr == 'systemd'
+      when: ansible_facts.service_mgr == 'systemd'
       changed_when: false
       failed_when: docker_service_status.stdout.strip() != "active"
 
     - name: Display Docker service status
       debug:
         msg: "Docker service is {{ docker_service_status.stdout.strip() }}"
-      when: ansible_service_mgr == 'systemd'
+      when: ansible_facts.service_mgr == 'systemd'
 
     - name: Pull the 'hello-world' image
       command: docker pull hello-world

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,17 @@
   vars:
     params:
       files:
-        - '{{ansible_distribution}}.yml'
-        - '{{ansible_os_family}}.yml'
+        - '{{ansible_facts.distribution}}.yml'
+        - '{{ansible_facts.os_family}}.yml'
         - main.yml
       paths:
         - 'vars'
 
 - include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - include_tasks: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Install Docker packages.
   package:
@@ -22,7 +22,7 @@
     state: "{{ docker_packages_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian']"
+  when: "ansible_version.full is version_compare('2.12', '<') or ansible_facts.os_family not in ['RedHat', 'Debian']"
 
 - name: Install Docker packages (with downgrade option).
   package:
@@ -31,7 +31,7 @@
     allow_downgrade: true
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
+  when: "ansible_version.full is version_compare('2.12', '>=') and ansible_facts.os_family in ['RedHat', 'Debian']"
 
 - name: Install docker-compose plugin.
   package:
@@ -39,7 +39,7 @@
     state: "{{ docker_compose_package_state }}"
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "docker_install_compose_plugin | bool == true and (ansible_version.full is version_compare('2.12', '<') or ansible_os_family not in ['RedHat', 'Debian'])"
+  when: "docker_install_compose_plugin | bool == true and (ansible_version.full is version_compare('2.12', '<') or ansible_facts.os_family not in ['RedHat', 'Debian'])"
 
 - name: Install docker-compose-plugin (with downgrade option).
   package:
@@ -48,7 +48,7 @@
     allow_downgrade: true
   notify: restart docker
   ignore_errors: "{{ ansible_check_mode }}"
-  when: "docker_install_compose_plugin | bool == true and ansible_version.full is version_compare('2.12', '>=') and ansible_os_family in ['RedHat', 'Debian']"
+  when: "docker_install_compose_plugin | bool == true and ansible_version.full is version_compare('2.12', '>=') and ansible_facts.os_family in ['RedHat', 'Debian']"
 
 - name: Ensure /etc/docker/ directory exists.
   file:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,8 +32,8 @@
   ansible.builtin.deb822_repository:
     name: docker
     types: deb
-    uris: "{{ docker_repo_url }}/{{ ansible_distribution | lower }}"
-    suites: "{{ ansible_distribution_release }}"
+    uris: "{{ docker_repo_url }}/{{ ansible_facts.distribution | lower }}"
+    suites: "{{ ansible_facts.distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"
     state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -55,4 +55,4 @@
       package:
         name: containerd.io
         state: present
-  when: ansible_distribution_major_version | int == 8
+  when: ansible_facts.distribution_major_version | int == 8


### PR DESCRIPTION
Currently, the role failed to run with `INJECT_FACTS_AS_VARS` set to `False` as the required `ansible_*` variables are not defined.

The configuration variable `INJECT_FACTS_AS_VARS` and the Ansible fact namespace `ansible_facts.*` have been added in Ansible 2.5. In the [porting guide of that version](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#ansible-fact-namespacing), it stated that:

> A new configuration variable, `inject_facts_as_vars`, has been added to ansible.cfg. Its default setting, 'True', keeps the 2.4 behavior of facts variables being set in the old `ansible_*` locations (while also writing them to the new namespace). This variable is expected to be set to 'False' in a future release. When `inject_facts_as_vars` is set to False, you must refer to ansible_facts through the new `ansible_facts.*` namespace.