### PR TITLE
Bump min Ansible version and add Debian Trixie platform

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Docker for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.10
+  min_ansible_version: 2.15.1
   platforms:
     - name: Fedora
       versions:
@@ -17,6 +17,7 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
+        - trixie
     - name: Ubuntu
       versions:
         - bionic


### PR DESCRIPTION
- Update min Ansible version to 2.15.1 (required for functional deb822 module)
- Adds Debian 13 Trixie as a supported platform