### PR TITLE
fix uri in repository file for debian based distributions

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,7 +32,7 @@
   ansible.builtin.deb822_repository:
     name: "{{ docker_apt_filename }}"
     types: deb
-    uris: "{{ docker_repo_url }}/{{ ansible_facts.distribution | lower }}"
+    uris: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
     suites: "{{ ansible_facts.distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"


### PR DESCRIPTION
Before the refactor in 7.5.0, the variable `docker_apt_ansible_distribution` was used to construct the URI instead of `ansible_facts.distribution`. I use this role on Debian-based [OSMC](https://osmc.tv/), where the resulting URI is incorrect unless I explicitly override it with that variable. Revert to the previous method of constructing the URI.