### PR TITLE
Allow the start command of the Docker service to be overwritten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A list of packages to be uninstalled prior to running this role. See [Docker's i
 docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true
+docker_service_start_command: ""
 docker_restart_handler_state: restarted
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ docker_obsolete_packages:
 docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true
+docker_service_start_command: ""
 docker_restart_handler_state: restarted
 
 # Docker Compose Plugin options.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,25 @@
   when: docker_daemon_options.keys() | length > 0
   notify: restart docker
 
+- name: Replace Docker service ExecStart command.
+  when: docker_service_start_command != ""
+  notify: restart docker
+  block:
+    - name: Get Docker service status
+      ansible.builtin.systemd_service:
+        name: docker
+      register: docker_service_status
+    - name: Patch docker.service
+      ansible.builtin.replace:
+        path: "{{ docker_service_status.status['FragmentPath'] }}"
+        regexp: "^ExecStart=.*$"
+        replace: "ExecStart={{ docker_service_start_command }}"
+      register: docker_service_patch
+    - name: Reload systemd services
+      service:
+        daemon_reload: true
+      when: docker_service_patch.changed
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker


### PR DESCRIPTION
I needed to set the 'docker_daemon_options' to the following:

```yml
docker_daemon_options : {
      "hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2375"]
    }
```

Afterwards, I could no longer start the Docker service, because the default ExecStart-Command on Rocky Linux 9 is `ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock`.

This results in the following error message:

```txt
unable to configure the Docker daemon with file /etc/docker/daemon.json: the following directives are specified both as a flag and in the configuration file: hosts: (from flag: [fd://], from file: [unix:///var/run/docker.sock tcp://0.0.0.0:2375])
```

I tried to fix this issue with the pull request :smile: . Thank you so much ❤️.