### PR TITLE
Control docker.socket in addition to docker.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ A list of packages to be uninstalled prior to running this role. See [Docker's i
 docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true
+docker_socket_state: started
+docker_socket_enabled: true
 docker_service_start_command: ""
 docker_restart_handler_state: restarted
 ```
 
-Variables to control the state of the `docker` service, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set `docker_service_manage` to `false`.
+Variables to control the state of the `docker` service and socket, and whether it should start on boot. If you're installing Docker inside a Docker container without systemd or sysvinit, you should set `docker_service_manage` to `false`.
 
 ```yaml
 docker_install_compose_plugin: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ docker_obsolete_packages:
 docker_service_manage: true
 docker_service_state: started
 docker_service_enabled: true
+docker_socket_state: started
+docker_socket_enabled: true
 docker_service_start_command: ""
 docker_restart_handler_state: restarted
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,6 +97,14 @@
   ignore_errors: "{{ ansible_check_mode }}"
   when: docker_service_manage | bool
 
+- name: Ensure docker.socket is started and enabled at boot.
+  service:
+    name: docker.socket
+    state: "{{ docker_socket_state }}"
+    enabled: "{{ docker_socket_enabled }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: docker_service_manage | bool
+
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers
 


### PR DESCRIPTION
This PR solve #332 and improve #276.
It does not change default behavior so it is fully retro-compatible.
It add fine control over the `docker.socket` service unit (the same as existing `docker.service`)
Tested on debian 12 systemd
Documentation included

Thx for your work ;)