### PR TITLE
fix(suse): update repo URL mapping to use numeric version paths

### DIFF
--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -21,17 +21,20 @@ docker_packages:
   - containerd
   - runc
 
-# Map SUSE releases to Docker repository paths
+# Map SUSE releases to Docker repository paths.
+#
+# As of 2024, download.opensuse.org/repositories/Virtualization:/containers/
+# uses numeric version paths (e.g. 15.5, 15.6, 15.7, 16.0) that match
+# ansible_facts.distribution_version directly for all Leap/SLES 15.x+ releases.
+# Only Tumbleweed and legacy SLES 12 SP5 require explicit mapping.
 docker_suse_release: >-
-  {% if ansible_facts.distribution_version is match('15\\.6') %}
-    openSUSE_Leap_15.6
-  {% elif ansible_facts.distribution_version is match('15\\.5') %}
-    openSUSE_Leap_15.5
-  {% elif ansible_facts.distribution_version is match('15\\.4') %}
-    openSUSE_Leap_15.4
-  {% else %}
+  {%- if 'Tumbleweed' in ansible_facts.distribution -%}
     openSUSE_Tumbleweed
-  {% endif %}
+  {%- elif ansible_facts.distribution_version is match('12\\.5') -%}
+    SLE_12_SP5
+  {%- else -%}
+    {{ ansible_facts.distribution_version }}
+  {%- endif -%}
 
 # Official Docker repo URL for openSUSE Leap
 docker_zypper_repo_url: >-


### PR DESCRIPTION
## Summary

The openSUSE OBS repository paths for Docker changed from `openSUSE_Leap_15.x` style to numeric `15.x` paths (e.g. `15.5`, `15.6`, `15.7`, `16.0`). The old paths no longer exist, causing installation failures on SLES 15.5+.

`ansible_facts.distribution_version` already returns the numeric version directly (e.g. `15.7`) for all SLES/Leap 15.x+ releases, so no explicit mapping is needed for these versions. Only Tumbleweed and the legacy SLES 12 SP5 require special handling.

## Changes

- Simplifies `docker_suse_release` mapping in `vars/Suse.yml` to use `ansible_facts.distribution_version` directly for all modern releases
- Retains explicit mappings only for `openSUSE_Tumbleweed` and `SLE_12_SP5`
- Adds inline documentation explaining the OBS repository path convention

## Testing

Verified on SLES 15 SP7 (`distribution_version = 15.7`) — repo URL resolves correctly to `https://download.opensuse.org/repositories/Virtualization:/containers/15.7/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)