### PR TITLE
Add docker_apt_distribution_release

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,14 @@ docker_apt_release_channel: stable
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
+docker_apt_distribution_release: "{{ ansible_facts.distribution_release }}"
 ```
 
 (Used only for Debian/Ubuntu.) You can switch the channel to `nightly` if you want to use the Nightly release.
 
 `docker_apt_ansible_distribution` is a workaround for Ubuntu variants which can't be identified as such by Ansible, and is only necessary until Docker officially supports them.
+
+Similarly, `docker_apt_distribution_release` is a workaround for OS releases that are still in development or do not match a Debian/Ubuntu codename, and is only necessary until Docker officially supports them.
 
 You can change `docker_apt_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror.
 `docker_apt_filename` controls the name of the source list file created in `sources.list.d`. If you are upgrading from an older (<7.0.0) version of this role, you should change this to the name of the existing file (e.g. `download_docker_com_linux_debian` on Debian) to avoid conflicting lists.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,9 @@ docker_apt_release_channel: stable
 # docker_apt_ansible_distribution is a workaround for Ubuntu variants which can't be identified as such by Ansible,
 # and is only necessary until Docker officially supports them.
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
+# docker_apt_distribution_release is a workaround for OS releases that are still in development
+# or do not match a Debian/Ubuntu codename, and is only necessary until Docker officially supports them.
+docker_apt_distribution_release: "{{ ansible_facts.distribution_release }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,7 +32,7 @@
     name: "{{ docker_apt_filename }}"
     types: deb
     uris: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
-    suites: "{{ ansible_facts.distribution_release }}"
+    suites: "{{ docker_apt_distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"
     state: "{{ 'present' if docker_add_repo | bool else 'absent' }}"


### PR DESCRIPTION
Add docker_apt_distribution_release to defaults; this allows overriding the distribution_release to use in the apt repository, and is necessary when Docker does not (yet) publish packages for the release. This typically occurs when the release is still in development, or is a Debian or Ubuntu variant that also uses different release names.