### PR TITLE
Allow overriding Debian Docker APT repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The main Docker repo URL, common between Debian and RHEL systems.
 ```yaml
 docker_apt_release_channel: stable
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
+docker_apt_repo_url: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 ```
@@ -103,6 +104,7 @@ docker_apt_filename: "docker"
 
 `docker_apt_ansible_distribution` is a workaround for Ubuntu variants which can't be identified as such by Ansible, and is only necessary until Docker officially supports them.
 
+You can change `docker_apt_repo_url` if you need to point Debian or Ubuntu systems at an internal mirror or cache.
 You can change `docker_apt_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror.
 `docker_apt_filename` controls the name of the source list file created in `sources.list.d`. If you are upgrading from an older (<7.0.0) version of this role, you should change this to the name of the existing file (e.g. `download_docker_com_linux_debian` on Debian) to avoid conflicting lists.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,8 @@ docker_apt_release_channel: stable
 # docker_apt_ansible_distribution is a workaround for Ubuntu variants which can't be identified as such by Ansible,
 # and is only necessary until Docker officially supports them.
 docker_apt_ansible_distribution: "{{ 'ubuntu' if ansible_facts.distribution in ['Pop!_OS', 'Linux Mint'] else ansible_facts.distribution }}"
+# docker_apt_repo_url can be changed if you need to point at an internal mirror or cache.
+docker_apt_repo_url: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
 docker_apt_gpg_key: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}/gpg"
 docker_apt_filename: "docker"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -31,7 +31,7 @@
   ansible.builtin.deb822_repository:
     name: "{{ docker_apt_filename }}"
     types: deb
-    uris: "{{ docker_repo_url }}/{{ docker_apt_ansible_distribution | lower }}"
+    uris: "{{ docker_apt_repo_url }}"
     suites: "{{ ansible_facts.distribution_release }}"
     components: "{{ docker_apt_release_channel }}"
     signed_by: "{{ docker_apt_gpg_key }}"


### PR DESCRIPTION
Adds docker_apt_repo_url and uses it in the Debian deb822_repository task so internal mirrors or caches can override the APT repo URL without replacing the full repository definition. Fixes #537.