### PR TITLE
fix(debian): correct docker.socket and obsolete-package handling for docker_add_repo: false

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Restart Docker socket (Debian/Ubuntu system packages).
+  ansible.builtin.service:
+    name: docker.socket
+    state: restarted
+  ignore_errors: "{{ ansible_check_mode }}"
+  when:
+    - docker_service_manage | bool
+    - ansible_facts.os_family == 'Debian'
+    - not docker_add_repo | bool
+  listen: restart docker
+
 - name: restart docker
   ansible.builtin.service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,17 @@
         daemon_reload: true
       when: docker_service_patch is changed
 
+- name: Ensure Docker socket is started and enabled at boot (Debian/Ubuntu system packages).
+  ansible.builtin.service:
+    name: docker.socket
+    state: "{{ docker_service_state }}"
+    enabled: "{{ docker_service_enabled }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  when:
+    - docker_service_manage | bool
+    - ansible_facts.os_family == 'Debian'
+    - not docker_add_repo | bool
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,6 +100,16 @@
     - ansible_facts.os_family == 'Debian'
     - not docker_add_repo | bool
 
+- name: Reset Docker service failed state (Debian/Ubuntu system packages).
+  ansible.builtin.command:
+    cmd: systemctl reset-failed docker.service
+  changed_when: false
+  failed_when: false
+  when:
+    - docker_service_manage | bool
+    - ansible_facts.os_family == 'Debian'
+    - not docker_add_repo | bool
+
 - name: Ensure Docker is started and enabled at boot.
   service:
     name: docker

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,10 +10,14 @@
     state: absent
 
 # See https://docs.docker.com/engine/install/debian/#uninstall-old-versions
+# Only remove obsolete packages when using the official Docker repo. When
+# docker_add_repo is false the user intentionally installs system packages
+# (e.g. docker.io on Ubuntu) which overlap with this list.
 - name: Ensure old versions of Docker are not installed.
   ansible.builtin.package:
     name: "{{ docker_obsolete_packages }}"
     state: absent
+  when: docker_add_repo | bool
 
 - name: Ensure legacy repo file is not present.
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

Two related fixes for the `docker_add_repo: false` scenario on Debian/Ubuntu, i.e. when Docker is installed from the distribution's own package repository (e.g. `docker.io` on Ubuntu) instead of Docker's official repo.

## Changes

### 1. Ensure `docker.socket` is managed when using system packages

Distro-packaged Docker (e.g. Ubuntu's `docker.io`) uses systemd socket activation with `PartOf=docker.service` on `docker.socket`. When the `restart docker` handler restarts `docker.service`, `docker.socket` is not restarted with it, leaving `dockerd` unable to find its socket fd after the restart.

Fix: start/enable `docker.socket` alongside `docker.service`, and restart it before `docker.service` in the handler (Debian/Ubuntu + `docker_add_repo: false` only).

Note: this is a narrower, targeted fix for the restart-handler ordering bug specifically. It doesn't overlap with #538, which adds generic `docker_socket_state`/`docker_socket_enabled` boot-state variables for all OS families but does not touch the restart handler.

### 2. Skip obsolete package removal when using system packages

When `docker_add_repo: false`, the user intentionally installs Docker from the distro repo (e.g. `docker.io`). The existing "remove obsolete packages" task removes it anyway, causing a remove/reinstall cycle that can leave the Docker service in a systemd `start-limit-hit` state. Also resets the service's failed state before starting, to recover from any leftover failure caused by the package's post-install scripts.

Fix: only remove obsolete packages when `docker_add_repo: true` (official Docker repo).

## Testing

Verified on Ubuntu with `docker_add_repo: false` (system `docker.io` package): `docker.socket` and `docker.service` both stay active and correctly restart via the handler, and repeated role runs no longer hit the remove/reinstall/start-limit-hit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)